### PR TITLE
This fix solves error: "‘ptrdiff_t’ does not name a type" for me.

### DIFF
--- a/include/llvm/ADT/SmallVector.h
+++ b/include/llvm/ADT/SmallVector.h
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <cstring>
 #include <memory>
+#include <cstddef>
 
 #ifdef _MSC_VER
 namespace std {

--- a/include/llvm/ADT/ilist.h
+++ b/include/llvm/ADT/ilist.h
@@ -40,6 +40,7 @@
 
 #include "llvm/ADT/iterator.h"
 #include <cassert>
+#include <cstddef>
 
 namespace llvm {
 

--- a/include/llvm/Use.h
+++ b/include/llvm/Use.h
@@ -28,6 +28,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/PointerIntPair.h"
+#include <cstddef>
 
 namespace llvm {
 


### PR DESCRIPTION
This seems to solve a build error that I get: "error: ‘ptrdiff_t’ does not name a type".

I assume ptrdiff_t has been recently moved from another std module or something of that ilk.

I could not find any specific reports related to llvm but for other cpp projects, like qt and openCV:
http://goo.gl/36taW
