### PR TITLE
Runtime stack overflow prevention for Twines

### DIFF
--- a/include/llvm/ADT/Twine.h
+++ b/include/llvm/ADT/Twine.h
@@ -182,6 +182,10 @@ namespace llvm {
       assert(isValid() && "Invalid twine!");
     }
 
+    /// Since the intended use of twines is as temporary objects, assignments 
+    /// when concatenating might cause undefined behavior or stack corruptions
+    Twine& operator=(const Twine &Other) LLVM_DELETED_FUNCTION;
+
     /// isNull - Check for the null twine.
     bool isNull() const {
       return getLHSKind() == NullKind;


### PR DESCRIPTION
Compile-time prevention of runtime stack overflow when concatenating Twines (infinite recursion). This doesn't seem a documented or intended behavior and can create subtle hard-to-debug problems. Please see the attached notes to learn more.
