### PR TITLE
Fix typo.

### DIFF
--- a/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -1,4 +1,4 @@
-//===-- CodeGen/MachineInstBuilder.h - Simplify creation of MIs -*- C++ -*-===//
+//===- CodeGen/MachineInstrBuilder.h - Simplify creation of MIs -*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //


### PR DESCRIPTION
Fix the comment typo of include/llvm/CodeGen/MachineInstrBuilder.h.
