### PR TITLE
output buffer do not needed to be empty.

### DIFF
--- a/lib/Support/ConvertUTFWrapper.cpp
+++ b/lib/Support/ConvertUTFWrapper.cpp
@@ -83,15 +83,16 @@ bool hasUTF16ByteOrderMark(ArrayRef<char> S) {
 }
 
 bool convertUTF16ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out) {
-  assert(Out.empty());
 
   // Error out on an uneven byte count.
   if (SrcBytes.size() % 2)
     return false;
 
   // Avoid OOB by returning early on empty input.
-  if (SrcBytes.empty())
+  if (SrcBytes.empty()) {
+    Out.clear();
     return true;
+  }
 
   const UTF16 *Src = reinterpret_cast<const UTF16 *>(SrcBytes.begin());
   const UTF16 *SrcEnd = reinterpret_cast<const UTF16 *>(SrcBytes.end());
@@ -140,10 +141,9 @@ bool convertUTF16ToUTF8String(ArrayRef<UTF16> Src, std::string &Out)
 
 bool convertUTF8ToUTF16String(StringRef SrcUTF8,
                               SmallVectorImpl<UTF16> &DstUTF16) {
-  assert(DstUTF16.empty());
-
   // Avoid OOB by returning early on empty input.
   if (SrcUTF8.empty()) {
+    DstUTF16.clear();
     DstUTF16.push_back(0);
     DstUTF16.pop_back();
     return true;


### PR DESCRIPTION
I found this issue here: https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin/pull/187
And then discussed here: http://lists.llvm.org/pipermail/llvm-bugs/2015-November/043236.html

I think it is not assert on the output buffer to be empty.
Besides, the `assert()` will opt out in release mode.
