### PR TITLE
Fix: wrong namespace used

### DIFF
--- a/docs/tutorial/LangImpl2.rst
+++ b/docs/tutorial/LangImpl2.rst
@@ -151,8 +151,8 @@ be generated with calls like this:
 
 .. code-block:: c++
 
-      auto LHS = llvm::make_unique<VariableExprAST>("x");
-      auto RHS = llvm::make_unique<VariableExprAST>("y");
+      auto LHS = helper::make_unique<VariableExprAST>("x");
+      auto RHS = helper::make_unique<VariableExprAST>("y");
       auto Result = std::make_unique<BinaryExprAST>('+', std::move(LHS),
                                                     std::move(RHS));
 
@@ -206,7 +206,7 @@ which parses that production. For numeric literals, we have:
 
     /// numberexpr ::= number
     static std::unique_ptr<ExprAST> ParseNumberExpr() {
-      auto Result = llvm::make_unique<NumberExprAST>(NumVal);
+      auto Result = helper::make_unique<NumberExprAST>(NumVal);
       getNextToken(); // consume the number
       return std::move(Result);
     }
@@ -272,7 +272,7 @@ function calls:
       getNextToken();  // eat identifier.
 
       if (CurTok != '(') // Simple variable ref.
-        return llvm::make_unique<VariableExprAST>(IdName);
+        return helper::make_unique<VariableExprAST>(IdName);
 
       // Call.
       getNextToken();  // eat (
@@ -296,7 +296,7 @@ function calls:
       // Eat the ')'.
       getNextToken();
 
-      return llvm::make_unique<CallExprAST>(IdName, std::move(Args));
+      return helper::make_unique<CallExprAST>(IdName, std::move(Args));
     }
 
 This routine follows the same style as the other routines. (It expects
@@ -499,7 +499,7 @@ then continue parsing:
         }
 
         // Merge LHS/RHS.
-        LHS = llvm::make_unique<BinaryExprAST>(BinOp, std::move(LHS),
+        LHS = helper::make_unique<BinaryExprAST>(BinOp, std::move(LHS),
                                                std::move(RHS));
       }  // loop around to the top of the while loop.
     }
@@ -529,7 +529,7 @@ above two blocks duplicated for context):
             return nullptr;
         }
         // Merge LHS/RHS.
-        LHS = llvm::make_unique<BinaryExprAST>(BinOp, std::move(LHS),
+        LHS = helper::make_unique<BinaryExprAST>(BinOp, std::move(LHS),
                                                std::move(RHS));
       }  // loop around to the top of the while loop.
     }
@@ -589,7 +589,7 @@ expressions):
       // success.
       getNextToken();  // eat ')'.
 
-      return llvm::make_unique<PrototypeAST>(FnName, std::move(ArgNames));
+      return helper::make_unique<PrototypeAST>(FnName, std::move(ArgNames));
     }
 
 Given this, a function definition is very simple, just a prototype plus
@@ -604,7 +604,7 @@ an expression to implement the body:
       if (!Proto) return nullptr;
 
       if (auto E = ParseExpression())
-        return llvm::make_unique<FunctionAST>(std::move(Proto), std::move(E));
+        return helper::make_unique<FunctionAST>(std::move(Proto), std::move(E));
       return nullptr;
     }
 
@@ -630,8 +630,8 @@ nullary (zero argument) functions for them:
     static std::unique_ptr<FunctionAST> ParseTopLevelExpr() {
       if (auto E = ParseExpression()) {
         // Make an anonymous proto.
-        auto Proto = llvm::make_unique<PrototypeAST>("", std::vector<std::string>());
-        return llvm::make_unique<FunctionAST>(std::move(Proto), std::move(E));
+        auto Proto = helper::make_unique<PrototypeAST>("", std::vector<std::string>());
+        return helper::make_unique<FunctionAST>(std::move(Proto), std::move(E));
       }
       return nullptr;
     }


### PR DESCRIPTION
This tutorial defines the namespace "helper", but then uses the namespace "llvm" in some places in the same file.
"llvm" as a namespace was not included in any way and thus produces errors when used instead "helper"