### PR TITLE
Update IRMover.cpp

### DIFF
--- a/lib/Linker/IRMover.cpp
+++ b/lib/Linker/IRMover.cpp
@@ -568,7 +568,7 @@ Value *IRLinker::materialize(Value *V, bool ForAlias) {
   // different, it means that the value already had a definition in the
   // destination module (linkonce for instance), but we need a new definition
   // for the alias ("New" will be different.
-  if (ForAlias && ValueMap.lookup(SGV) == New)
+  if (ForAlias && ValueMap.lookup(SGV) == New) // Is this correct to handle all cases? What about AliasValueMap?
     return New;
 
   if (ForAlias || shouldLink(New, *SGV))


### PR DESCRIPTION
Using llvm-link on a module triggeres an assert. I can not strip the module down to isolate the problem. The check (AliasValueMap.lookup(SGV) == New) seems to do what was intended by the commented line but perhaps someone knows better.

llvm-link: llvm/lib/Transforms/Utils/ValueMapper.cpp:981: void (anonymous namespace)::Mapper::scheduleMapGlobalInitializer(llvm::GlobalVariable &, llvm::Constant &, unsigned int): Assertion `AlreadyScheduled.insert(&GV).second && "Should not reschedule"' failed.
