### PR TITLE
Fix compilation issue with Cygwin

### DIFF
--- a/lib/Support/Unix/Signals.inc
+++ b/lib/Support/Unix/Signals.inc
@@ -412,7 +412,7 @@ void llvm::sys::PrintStackTrace(raw_ostream &OS) {
 
   if (printSymbolizedStackTrace(Argv0, StackTrace, depth, OS))
     return;
-#if HAVE_DLFCN_H && __GNUG__
+#if !defined(__CYGWIN__) && HAVE_DLFCN_H && __GNUG__
   int width = 0;
   for (int i = 0; i < depth; ++i) {
     Dl_info dlinfo;


### PR DESCRIPTION
Currently LLVM does not compile on Cygwin with recent versions of CMake. This patch fixes the issue. Please see the following for reference:

http://lists.llvm.org/pipermail/llvm-dev/2016-June/101790.html
