### PR TITLE
fix the bug of opening the file with the bytes can't be decoded to 'u…

### DIFF
--- a/tools/sancov/coverage-report-server.py
+++ b/tools/sancov/coverage-report-server.py
@@ -160,7 +160,7 @@ class ServerHandler(http.server.BaseHTTPRequestHandler):
 
             linemap = self.symcov_data.compute_linemap(filename)
 
-            with open(filepath, 'r') as f:
+            with open(filepath, 'r' ,encoding='utf-8', errors='replace') as f:
                 content = "\n".join(
                         ["<span class='{cls}'>{line}&nbsp;</span>".format(
                             line=html.escape(line.rstrip()), 


### PR DESCRIPTION
…tf-8'

fix the bug  as blow:
my_ip - - [28/May/2017 17:16:23] "GET /TestDraft.cpp HTTP/1.1" 200 -
----------------------------------------
Exception happened during processing of request from ('my_ip', 56600)
Traceback (most recent call last):
  File "/usr/lib/python3.4/socketserver.py", line 305, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python3.4/socketserver.py", line 331, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python3.4/socketserver.py", line 344, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.4/socketserver.py", line 673, in __init__
    self.handle()
  File "/usr/lib/python3.4/http/server.py", line 398, in handle
    self.handle_one_request()
  File "/usr/lib/python3.4/http/server.py", line 386, in handle_one_request
    method()
  File "/home/workspace/coverage-report-server.py", line 165, in do_GET
    for line_no, line in enumerate(f, start=1)])
  File "/home/workspace/coverage-report-server.py", line 162, in <listcomp>
    ["<span class='{cls}'>{line}&nbsp;</span>".format(
  File "/usr/lib/python3.4/codecs.py", line 319, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb5 in position 4164: invalid start byte
----------------------------------------