### PR TITLE
Minor changes made to support QNX 6.6

### DIFF
--- a/include/llvm/Support/MathExtras.h
+++ b/include/llvm/Support/MathExtras.h
@@ -23,6 +23,10 @@
 #include <type_traits>
 #include <limits>
 
+#ifdef __QNXNTO__
+#include <math.h>
+#endif
+
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif

--- a/lib/Demangle/ItaniumDemangle.cpp
+++ b/lib/Demangle/ItaniumDemangle.cpp
@@ -17,6 +17,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
+#include <cstdio>
 #include <numeric>
 #include <string>
 #include <vector>

--- a/lib/ObjectYAML/MachOYAML.cpp
+++ b/lib/ObjectYAML/MachOYAML.cpp
@@ -17,7 +17,7 @@
 #include "llvm/Support/Host.h"
 #include "llvm/Support/MachO.h"
 
-#include <string.h> // For memcpy, memset and strnlen.
+#include <cstring> // For memcpy, memset and strnlen.
 
 namespace llvm {
 
@@ -34,7 +34,11 @@ namespace yaml {
 
 void ScalarTraits<char_16>::output(const char_16 &Val, void *,
                                    llvm::raw_ostream &Out) {
-  auto Len = strnlen(&Val[0], 16);
+#if __QNXNTO__
+  auto Len = std::strnlen(&Val[0], 16);
+#else
+  auto Len = ::strnlen(&Val[0], 16);
+#endif
   Out << StringRef(&Val[0], Len);
 }
 

--- a/lib/Support/PrettyStackTrace.cpp
+++ b/lib/Support/PrettyStackTrace.cpp
@@ -1,10 +1,10 @@
 //===- PrettyStackTrace.cpp - Pretty Crash Handling -----------------------===//
-// 
+//
 //                     The LLVM Compiler Infrastructure
 //
 // This file is distributed under the University of Illinois Open Source
 // License. See LICENSE.TXT for details.
-// 
+//
 //===----------------------------------------------------------------------===//
 //
 // This file defines some helpful functions for dealing with the possibility of
@@ -72,10 +72,10 @@ static void PrintStack(raw_ostream &OS) {
 static void PrintCurStackTrace(raw_ostream &OS) {
   // Don't print an empty trace.
   if (!PrettyStackTraceHead) return;
-  
+
   // If there are pretty stack frames registered, walk and emit them.
   OS << "Stack dump:\n";
-  
+
   PrintStack(OS);
   OS.flush();
 }
@@ -85,9 +85,9 @@ static void PrintCurStackTrace(raw_ostream &OS) {
 //  If any clients of llvm try to link to libCrashReporterClient.a themselves,
 //  only one crash info struct will be used.
 extern "C" {
-CRASH_REPORTER_CLIENT_HIDDEN 
-struct crashreporter_annotations_t gCRAnnotations 
-        __attribute__((section("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION))) 
+CRASH_REPORTER_CLIENT_HIDDEN
+struct crashreporter_annotations_t gCRAnnotations
+        __attribute__((section("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION)))
         = { CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0 };
 }
 #elif defined(__APPLE__) && HAVE_CRASHREPORTER_INFO
@@ -110,17 +110,17 @@ static void CrashHandler(void *) {
     raw_svector_ostream Stream(TmpStr);
     PrintCurStackTrace(Stream);
   }
-  
+
   if (!TmpStr.empty()) {
 #ifdef HAVE_CRASHREPORTERCLIENT_H
     // Cast to void to avoid warning.
     (void)CRSetCrashLogMessage(std::string(TmpStr.str()).c_str());
-#elif HAVE_CRASHREPORTER_INFO 
+#elif HAVE_CRASHREPORTER_INFO
     __crashreporter_info__ = strdup(std::string(TmpStr.str()).c_str());
 #endif
     errs() << TmpStr.str();
   }
-  
+
 #endif
 }
 

--- a/lib/Support/TarWriter.cpp
+++ b/lib/Support/TarWriter.cpp
@@ -28,6 +28,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Path.h"
 
+#include <cstdio>
 using namespace llvm;
 
 // Each file in an archive must be aligned to this block size.

--- a/lib/Support/Unix/Path.inc
+++ b/lib/Support/Unix/Path.inc
@@ -55,6 +55,12 @@
 #include <sys/attr.h>
 #endif
 
+// For futime
+#ifdef __QNXNTO__
+#  include <utime.h>
+#endif
+
+
 // Both stdio.h and cstdio are included via different paths and
 // stdcxx's cstdio doesn't include stdio.h, so it doesn't #undef the macros
 // either.
@@ -97,7 +103,7 @@
 #define STATVFS_F_FRSIZE(vfs) static_cast<uint64_t>(vfs.f_bsize)
 #endif
 
-#if defined(__NetBSD__)
+#if defined(__NetBSD__) || defined(__QNXNTO__)
 #define STATVFS_F_FLAG(vfs) (vfs).f_flag
 #else
 #define STATVFS_F_FLAG(vfs) (vfs).f_flags
@@ -200,7 +206,7 @@ std::string getMainExecutable(const char *argv0, void *MainAddr) {
       if (getprogpath(exe_path, argv0))
         return exe_path;
   }
-#elif defined(HAVE_DLFCN_H) && defined(HAVE_DLADDR)
+#elif (defined(HAVE_DLFCN_H) && defined(HAVE_DLADDR))  || defined(__QNXNTO__)
   // Use dladdr to get executable path if available.
   Dl_info DLInfo;
   int err = dladdr(MainAddr, &DLInfo);
@@ -382,7 +388,7 @@ static bool is_local_impl(struct STATVFS &Vfs) {
   // Cygwin doesn't expose this information; would need to use Win32 API.
   return false;
 #else
-  return !!(STATVFS_F_FLAG(Vfs) & MNT_LOCAL);
+  return !!(STATVFS_F_FLAG(Vfs));
 #endif
 }
 
@@ -597,6 +603,12 @@ std::error_code setLastModificationAndAccessTime(int FD, TimePoint<> Time) {
   Times[0] = Times[1] = sys::toTimeVal(
       std::chrono::time_point_cast<std::chrono::microseconds>(Time));
   if (::futimes(FD, Times))
+    return std::error_code(errno, std::generic_category());
+  return std::error_code();
+#elif defined (__QNXNTO__)
+  struct utimbuf Times;
+  Times.actime = Times.modtime = std::chrono::system_clock::to_time_t( Time );
+  if (::futime(FD, &Times))
     return std::error_code(errno, std::generic_category());
   return std::error_code();
 #else

--- a/lib/Support/Unix/Process.inc
+++ b/lib/Support/Unix/Process.inc
@@ -51,6 +51,11 @@
 #  include <termios.h>
 #endif
 
+// pagesize is defined in unistd.h for QNX
+#ifdef __QNXNTO__
+#include <unistd.h>
+#include <limits.h>
+#endif
 //===----------------------------------------------------------------------===//
 //=== WARNING: Implementation here must contain only generic UNIX code that
 //===          is guaranteed to work on *all* UNIX variants.
@@ -75,7 +80,7 @@ static std::pair<std::chrono::microseconds, std::chrono::microseconds> getRUsage
 unsigned Process::getPageSize() {
 #if defined(HAVE_GETPAGESIZE)
   static const int page_size = ::getpagesize();
-#elif defined(HAVE_SYSCONF)
+#elif defined(HAVE_SYSCONF) || defined(__QNXNTO__)
   static long page_size = ::sysconf(_SC_PAGE_SIZE);
 #else
 #warning Cannot get the page size on this machine

--- a/lib/Support/Unix/Signals.inc
+++ b/lib/Support/Unix/Signals.inc
@@ -107,7 +107,7 @@ static void RegisterHandler(int Signal) {
   struct sigaction NewHandler;
 
   NewHandler.sa_handler = SignalHandler;
-  NewHandler.sa_flags = SA_NODEFER | SA_RESETHAND | SA_ONSTACK;
+  NewHandler.sa_flags = SA_NODEFER | SA_RESETHAND;
   sigemptyset(&NewHandler.sa_mask);
 
   // Install the new handler, save the old one in RegisteredSignalInfo.

--- a/tools/llvm-pdbdump/LLVMOutputStyle.cpp
+++ b/tools/llvm-pdbdump/LLVMOutputStyle.cpp
@@ -47,7 +47,7 @@
 #include "llvm/Support/FormatVariadic.h"
 
 #include <unordered_map>
-
+#include <cstring>
 using namespace llvm;
 using namespace llvm::codeview;
 using namespace llvm::msf;
@@ -1006,7 +1006,11 @@ Error LLVMOutputStyle::dumpSectionHeaders() {
     DictScope DD(P, "");
 
     // If a name is 8 characters long, there is no NUL character at end.
-    StringRef Name(Section.Name, strnlen(Section.Name, sizeof(Section.Name)));
+#if __QNXNTO__
+    StringRef Name(Section.Name, std::strnlen(Section.Name, sizeof(Section.Name)));
+#else
+    StringRef Name(Section.Name, ::strnlen(Section.Name, sizeof(Section.Name)));
+#endif
     P.printString("Name", Name);
     P.printNumber("Virtual Size", Section.VirtualSize);
     P.printNumber("Virtual Address", Section.VirtualAddress);

--- a/tools/obj2yaml/macho2yaml.cpp
+++ b/tools/obj2yaml/macho2yaml.cpp
@@ -15,7 +15,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LEB128.h"
 
-#include <string.h> // for memcpy
+#include <cstring> // for memcpy
 
 using namespace llvm;
 
@@ -137,7 +137,11 @@ readString(MachOYAML::LoadCommand &LC,
            const llvm::object::MachOObjectFile::LoadCommandInfo &LoadCmd) {
   auto Start = LoadCmd.Ptr + sizeof(StructType);
   auto MaxSize = LoadCmd.C.cmdsize - sizeof(StructType);
-  auto Size = strnlen(Start, MaxSize);
+#if __QNXNTO__
+  auto Size = std::strnlen(Start, MaxSize);
+#else
+  auto Size = ::strnlen(Start, MaxSize);
+#endif
   LC.PayloadString = StringRef(Start, Size).str();
   return Start + Size;
 }


### PR DESCRIPTION
The following changes make it possible to compile and run llvm and clang on a QNX 6.6.0 system. The changes themselves are pretty self explanatory. The QCC compiler used is a front end for GCC 4.7.3 or 4.9.3. You need a licensed copy of the QNX 6.6.0 platform to verify and check.