### PR TITLE
fix crash on thumb backend, only visit first and last operands of GEP on ConstantHoisting

### DIFF
--- a/lib/Transforms/Scalar/ConstantHoisting.cpp
+++ b/lib/Transforms/Scalar/ConstantHoisting.cpp
@@ -367,6 +367,12 @@ void ConstantHoistingPass::collectConstantCandidates(
 
   // Scan all operands.
   for (unsigned Idx = 0, E = Inst->getNumOperands(); Idx != E; ++Idx) {
+    if (Idx != 0 && Idx != E - 1 && dyn_cast<GetElementPtrInst>(Inst)) {
+      // skip constant int in GEP as the CodeGenPrepare require at most
+      // one variable offset.
+      continue;
+    }
+
     Value *Opnd = Inst->getOperand(Idx);
 
     // Visit constant integers.


### PR DESCRIPTION



# reproduce


[f.bitcode.txt](https://github.com/llvm-mirror/llvm/files/1066011/f.bitcode.txt)

```
%struct.hugestruct = type { [256 x i8], [256 x i8], [256 x i8], ... }
define void @f(%struct.hugestruct* readonly) {
  %2 = getelementptr inbounds %struct.hugestruct, %struct.hugestruct* %0, i32 0, i32 255, i32 1
  %3 = getelementptr inbounds %struct.hugestruct, %struct.hugestruct* %0, i32 0, i32 256, i32 2
  %4 = getelementptr inbounds %struct.hugestruct, %struct.hugestruct* %0, i32 0, i32 257, i32 3
  %5 = load i8, i8* %2
  %6 = load i8, i8* %3
  ret void
}
```
```bash
llvm-as f.bitcode.txt -o f.bc
llc -O2 f.bc -march=thumb
```
# crash
```
#0 0x0000000000dffa24 PrintStackTraceSignalHandler(void*) (/home/bob/projects/llvm-build/bin/llc+0xdffa24)
#1 0x0000000000dffcf6 SignalHandler(int) (/home/bob/projects/llvm-build/bin/llc+0xdffcf6)
#2 0x0000000000f0aa50 __restore_rt (/home/bob/projects/llvm-build/bin/llc+0xf0aa50)
#3 0x0000000000720cb3 (anonymous namespace)::AddressingModeMatcher::matchOperationAddr(llvm::User*, unsigned int, unsigned int, bool*) (/home/bob/projects/llvm-build/bin/llc+0x720cb3)
#4 0x0000000000720147 (anonymous namespace)::AddressingModeMatcher::matchAddr(llvm::Value*, unsigned int) (/home/bob/projects/llvm-build/bin/llc+0x720147)
#5 0x000000000071a34b (anonymous namespace)::CodeGenPrepare::optimizeMemoryInst(llvm::Instruction*, llvm::Value*, llvm::Type*, unsigned int) (/home/bob/projects/llvm-build/bin/llc+0x71a34b)
#6 0x0000000000714a07 (anonymous namespace)::CodeGenPrepare::optimizeInst(llvm::Instruction*, bool&) (/home/bob/projects/llvm-build/bin/llc+0x714a07)
#7 0x000000000070d15e (anonymous namespace)::CodeGenPrepare::runOnFunction(llvm::Function&) (/home/bob/projects/llvm-build/bin/llc+0x70d15e)
#8 0x00000000009d78c3 llvm::FPPassManager::runOnFunction(llvm::Function&) (/home/bob/projects/llvm-build/bin/llc+0x9d78c3)
#9 0x00000000009d7ab3 llvm::FPPassManager::runOnModule(llvm::Module&) (/home/bob/projects/llvm-build/bin/llc+0x9d7ab3)
#10 0x00000000009d7eba llvm::legacy::PassManagerImpl::run(llvm::Module&) (/home/bob/projects/llvm-build/bin/llc+0x9d7eba)
#11 0x000000000043de7a compileModule(char**, llvm::LLVMContext&) (/home/bob/projects/llvm-build/bin/llc+0x43de7a)
#12 0x000000000043b0eb main (/home/bob/projects/llvm-build/bin/llc+0x43b0eb)
#13 0x00000000011dee1d generic_start_main (/home/bob/projects/llvm-build/bin/llc+0x11dee1d)
#14 0x00000000011df08d __libc_start_main (/home/bob/projects/llvm-build/bin/llc+0x11df08d)
#15 0x000000000043a5ea _start (/home/bob/projects/llvm-build/bin/llc+0x43a5ea)
Stack dump:
0.      Program arguments: /home/bob/projects/llvm-build/bin/llc -O2 z.bc -march=thumb
1.      Running pass 'Function Pass Manager' on module 'z.bc'.
2.      Running pass 'CodeGen Prepare' on function '@f'
Segmentation fault (core dumped)
```
# cause
the constantInt index in GEP is translated to a bitcast value by ConstantHoisting

