### PR TITLE
Remove uses of deprecated std::unary_function, binary_function, and pointer_to_unary_function.

### DIFF
--- a/include/llvm/ADT/STLExtras.h
+++ b/include/llvm/ADT/STLExtras.h
@@ -57,7 +57,10 @@ using ValueOfRange = typename std::remove_reference<decltype(
 //===----------------------------------------------------------------------===//
 
 template<class Ty>
-struct identity : public std::unary_function<Ty, Ty> {
+struct identity {
+  typedef Ty argument_type;
+  typedef Ty result_type;
+
   Ty &operator()(Ty &self) const {
     return self;
   }
@@ -67,14 +70,22 @@ struct identity : public std::unary_function<Ty, Ty> {
 };
 
 template<class Ty>
-struct less_ptr : public std::binary_function<Ty, Ty, bool> {
+struct less_ptr {
+  typedef Ty first_argument_type;
+  typedef Ty second_argument_type;
+  typedef bool result_Type;
+
   bool operator()(const Ty* left, const Ty* right) const {
     return *left < *right;
   }
 };
 
 template<class Ty>
-struct greater_ptr : public std::binary_function<Ty, Ty, bool> {
+struct greater_ptr {
+  typedef Ty first_argument_type;
+  typedef Ty second_argument_type;
+  typedef bool result_Type;
+
   bool operator()(const Ty* left, const Ty* right) const {
     return *right < *left;
   }

--- a/include/llvm/CodeGen/LatencyPriorityQueue.h
+++ b/include/llvm/CodeGen/LatencyPriorityQueue.h
@@ -22,7 +22,11 @@ namespace llvm {
   class LatencyPriorityQueue;
 
   /// Sorting functions for the Available queue.
-  struct latency_sort : public std::binary_function<SUnit*, SUnit*, bool> {
+  struct latency_sort {
+    typedef SUnit* first_argument_type;
+    typedef SUnit* second_argument_type;
+    typedef bool result_Type;
+
     LatencyPriorityQueue *PQ;
     explicit latency_sort(LatencyPriorityQueue *pq) : PQ(pq) {}
 

--- a/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/include/llvm/CodeGen/MachineBasicBlock.h
@@ -762,8 +762,10 @@ private:
 raw_ostream& operator<<(raw_ostream &OS, const MachineBasicBlock &MBB);
 
 // This is useful when building IndexedMaps keyed on basic block pointers.
-struct MBB2NumberFunctor :
-  public std::unary_function<const MachineBasicBlock*, unsigned> {
+struct MBB2NumberFunctor {
+  typedef const MachineBasicBlock* argument_type;
+  typedef unsigned result_type;
+
   unsigned operator()(const MachineBasicBlock *MBB) const {
     return MBB->getNumber();
   }

--- a/include/llvm/CodeGen/ResourcePriorityQueue.h
+++ b/include/llvm/CodeGen/ResourcePriorityQueue.h
@@ -28,7 +28,11 @@ namespace llvm {
   class ResourcePriorityQueue;
 
   /// Sorting functions for the Available queue.
-  struct resource_sort : public std::binary_function<SUnit*, SUnit*, bool> {
+  struct resource_sort {
+    typedef SUnit* first_argument_type;
+    typedef SUnit* second_argument_type;
+    typedef bool result_type;
+
     ResourcePriorityQueue *PQ;
     explicit resource_sort(ResourcePriorityQueue *pq) : PQ(pq) {}
 

--- a/include/llvm/IR/Instructions.h
+++ b/include/llvm/IR/Instructions.h
@@ -4195,11 +4195,10 @@ private:
   }
 
 public:
-  using DerefFnTy = std::pointer_to_unary_function<Value *, BasicBlock *>;
+  typedef BasicBlock* (*DerefFnTy)(Value *);
   using handler_iterator = mapped_iterator<op_iterator, DerefFnTy>;
   using handler_range = iterator_range<handler_iterator>;
-  using ConstDerefFnTy =
-      std::pointer_to_unary_function<const Value *, const BasicBlock *>;
+  typedef const BasicBlock* (*ConstDerefFnTy)(const Value *);
   using const_handler_iterator =
       mapped_iterator<const_op_iterator, ConstDerefFnTy>;
   using const_handler_range = iterator_range<const_handler_iterator>;

--- a/include/llvm/Target/TargetRegisterInfo.h
+++ b/include/llvm/Target/TargetRegisterInfo.h
@@ -1114,7 +1114,10 @@ public:
 };
 
 // This is useful when building IndexedMaps keyed on virtual registers
-struct VirtReg2IndexFunctor : public std::unary_function<unsigned, unsigned> {
+struct VirtReg2IndexFunctor {
+  typedef unsigned argument_type;
+  typedef unsigned result_type;
+
   unsigned operator()(unsigned Reg) const {
     return TargetRegisterInfo::virtReg2Index(Reg);
   }

--- a/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
+++ b/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
@@ -1563,7 +1563,11 @@ void ScheduleDAGRRList::ListScheduleBottomUp() {
 namespace {
 class RegReductionPQBase;
 
-struct queue_sort : public std::binary_function<SUnit*, SUnit*, bool> {
+struct queue_sort {
+  typedef SUnit* first_argument_type;
+  typedef SUnit* second_argument_type;
+  typedef bool result_type;
+
   bool isReady(SUnit* SU, unsigned CurCycle) const { return true; }
 };
 

--- a/utils/TableGen/SequenceToOffsetTable.h
+++ b/utils/TableGen/SequenceToOffsetTable.h
@@ -37,7 +37,11 @@ class SequenceToOffsetTable {
 
   // Define a comparator for SeqT that sorts a suffix immediately before a
   // sequence with that suffix.
-  struct SeqLess : public std::binary_function<SeqT, SeqT, bool> {
+  struct SeqLess {
+    typedef SeqT first_argument_type;
+    typedef SeqT second_argument_type;
+    typedef bool result_type;
+
     Less L;
     bool operator()(const SeqT &A, const SeqT &B) const {
       return std::lexicographical_compare(A.rbegin(), A.rend(),


### PR DESCRIPTION
This permits LLVM to be built in Visual Studio 2017 with the C++17 dialect, via /std:c++latest