### PR TITLE
Add CodeView directive documentation

### DIFF
--- a/docs/Extensions.rst
+++ b/docs/Extensions.rst
@@ -329,6 +329,71 @@ symbol is undefined, then that symbol is defined as if ``.weak symbol`` has been
 written at the end of the file.  This forces the symbol to show up in the symbol
 table.
 
+CodeView-Dependent
+------------------
+
+``.cv_file`` Directive
+^^^^^^^^^^^^^^^^^^^^^^
+Syntax:
+  ``.cv_file FileNumber FileName [checksum] [checksumkind]``
+
+``.cv_func_id`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Introduces a function ID that can be used with .cv_loc.
+
+Syntax:
+  ``.cv_func_id FunctionId``
+
+``.cv_inline_site_id`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Introduces a function ID that can be used with .cv_loc. Includes "inlined at"
+source location information for use in the line table of the caller, whether the
+caller is a real function or another inlined call site.
+
+Syntax:
+  ``.cv_inline_site_id FunctionId "within" Function "inlined_at" FileNumber Line [Colomn]``
+
+``.cv_loc`` Directive
+^^^^^^^^^^^^^^^^^^^^^
+The first number is a file number, must have been previously assigned with a
+.file directive, the second number is the line number and optionally the third
+number is a column position (zero if not specified).  The remaining optional
+items are .loc sub-directives.
+
+Syntax:
+  ``.cv_loc FunctionId FileNumber [Line] [Column] [prologue_end] [is_stmt VALUE]``
+
+``.cv_linetable`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Syntax:
+  ``.cv_linetable FunctionId, FunctionStart, FunctionEnd``
+
+``.cv_inline_linetable`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Syntax:
+  ``.cv_inline_linetable PrimaryFunctionId, FileNumber Line FunctionStart FunctionEnd``
+
+``.cv_def_range`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Syntax:
+  ``.cv_def_range RangeStart RangeEnd (GapStart GapEnd)* bytes*``
+
+``.cv_stringtable`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``.cv_filechecksums`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``.cv_filechecksumoffset`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Syntax:
+  ``.cv_filechecksumoffset FileNumber``
+
+``.cv_fpo_data`` Directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+Syntax:
+  ``.cv_fpo_data procsym``
+
 Target Specific Behaviour
 =========================
 


### PR DESCRIPTION
I wanted a more central place to hold CodeView assembly directives. Most of this information was taken from [AsmParser.cpp](https://github.com/llvm-mirror/llvm/blob/a94df7d526ce45abe6b10f04b4a73a3aa3bef0a4/lib/MC/MCParser/AsmParser.cpp#L3568)