### PR TITLE
 * detect and differentiate ARM hard/soft-float

### DIFF
--- a/include/llvm/ADT/Triple.h
+++ b/include/llvm/ADT/Triple.h
@@ -621,6 +621,30 @@ public:
   /// Tests whether the target is Android
   bool isAndroid() const { return getEnvironment() == Triple::Android; }
 
+  /// Tests whether the target is an EABI variant
+  bool isEABI() const {
+      return getEnvironment() == Triple::GNUEABI ||
+             getEnvironment() == Triple::GNUEABIHF ||
+             getEnvironment() == Triple::EABI ||
+             getEnvironment() == Triple::EABIHF ||
+             getEnvironment() == Triple::MuslEABI ||
+             getEnvironment() == Triple::MuslEABIHF;
+  }
+
+  /// Tests whether the target is a hard-float EABI variant
+  bool isHardFloatEABI() const {
+      return getEnvironment() == Triple::GNUEABIHF ||
+             getEnvironment() == Triple::EABIHF ||
+             getEnvironment() == Triple::MuslEABIHF;
+  }
+
+  /// Tests whether the target is a soft-float EABI variant
+  bool isSoftFloatEABI() const {
+      return getEnvironment() == Triple::GNUEABI ||
+             getEnvironment() == Triple::EABI ||
+             getEnvironment() == Triple::MuslEABI;
+  }
+
   bool isAndroidVersionLT(unsigned Major) const {
     assert(isAndroid() && "Not an Android triple!");
 
@@ -751,6 +775,24 @@ public:
   /// \returns A new triple with a 64-bit architecture or an unknown
   ///          architecture if no such variant can be found.
   llvm::Triple get64BitArchVariant() const;
+
+  /// Form a triple with a hard-float variant of the current architecture.
+  ///
+  /// This can be used to move across "families" of architectures where useful.
+  ///
+  /// \returns A new triple with a hard float variant of the current
+  ///          architecture or an unknown architecture if no such variant
+  ///          can be found.
+  llvm::Triple getHardFloatArchVariant() const;
+
+  /// Form a triple with a soft-float variant of the current architecture.
+  ///
+  /// This can be used to move across "families" of architectures where useful.
+  ///
+  /// \returns A new triple with a soft float variant of the current
+  ///          architecture or an unknown architecture if no such variant
+  ///          can be found.
+  llvm::Triple getSoftFloatArchVariant() const;
 
   /// Form a triple with a big endian variant of the current architecture.
   ///

--- a/lib/Support/Triple.cpp
+++ b/lib/Support/Triple.cpp
@@ -1390,6 +1390,65 @@ Triple Triple::get64BitArchVariant() const {
   return T;
 }
 
+Triple Triple::getHardFloatArchVariant() const {
+  Triple T(*this);
+  // A few architectures are guaranteed to *always* be hard-float.
+  switch (getArch()) {
+  case Triple::aarch64:
+  case Triple::aarch64_be:
+  case Triple::sparcv9:
+  case Triple::x86_64:
+    // Always hard-float
+    return T;
+  }
+
+  // Hard-float vs soft-float triples are normally distinguished by
+  // environment rather than architecture (i.e. GNUEABI vs GNUEABIHF).
+  switch (getEnvironment()) {
+  case Triple::EABIHF:
+  case Triple::GNUEABIHF:
+  case Triple::MuslEABIHF:
+    // Already hard-float.
+    break;
+  case Triple::EABI:     T.setEnvironment(Triple::EABIHF);     break;
+  case Triple::GNUEABI:  T.setEnvironment(Triple::GNUEABIHF);  break;
+  case Triple::MuslEABI: T.setEnvironment(Triple::MuslEABIHF); break;
+  default:
+    T.setArch(UnknownArch);
+  }
+  return T;
+}
+
+Triple Triple::getSoftFloatArchVariant() const {
+  Triple T(*this);
+  // A few architectures are guaranteed to *always* be hard-float.
+  switch (getArch()) {
+  case Triple::aarch64:
+  case Triple::aarch64_be:
+  case Triple::sparcv9:
+  case Triple::x86_64:
+    // No soft-float variant.
+    T.setArch(UnknownArch);
+    return T;
+  }
+
+  // Hard-float vs soft-float triples are normally distinguished by
+  // environment rather than architecture (i.e. GNUEABI vs GNUEABIHF).
+  switch (getEnvironment()) {
+  case Triple::EABI:
+  case Triple::GNUEABI:
+  case Triple::MuslEABI:
+    // Already soft-float.
+    break;
+  case Triple::EABIHF:     T.setEnvironment(Triple::EABI);     break;
+  case Triple::GNUEABIHF:  T.setEnvironment(Triple::GNUEABI);  break;
+  case Triple::MuslEABIHF: T.setEnvironment(Triple::MuslEABI); break;
+  default:
+    T.setArch(UnknownArch);
+  }
+  return T;
+}
+
 Triple Triple::getBigEndianArchVariant() const {
   Triple T(*this);
   // Already big endian.


### PR DESCRIPTION
I'm adding this in to support hard-float/soft-float biarch conventions on 32-bit ARM platforms.  Be prepared for some related PRs for clang and compiler-rt once I've run through the test suite, but they will depend on this PR being merged first.

FYI I'm testing with gcc-8.2.0+binutils-2.31.1+glibc-2.27+linux-2.16.15.  Some other issues I've noted that I'm not fixing just yet:

1) There seems to be some failures with parallel-build (using make -j4), due to some *.inc files apparently not getting fully generated by the time other source files need them.  I'll poke around with this a bit more later, so I'll at least have some build logs to produce on request.

(Yes, I tried building in parallel.   My build box has four cores and 16GB of RAM, so I'd be insane not to try, even with LLVM.)

2) What exactly do you guys expect for multilib when building an AArch64 target?  When building for AArch64 targets, I noticed the Makefiles trying to build certain things with a bunch of AArch32-specific flags.  I hope you understand that you can't get both 64-bit and 32-bit ARM builds out of the same toolchain, at least with GNU toolchains.  I'm currently building the ARMv7 targets in dedicated chroots with separate ARMv7 toolchains.