### PR TITLE
[BPF][BTF] Add BTF generation if the target is BPF

### DIFF
--- a/include/llvm/MC/MCBTFContext.h
+++ b/include/llvm/MC/MCBTFContext.h
@@ -1,0 +1,370 @@
+//===- MCBTFContext.h ---------------------------------------- *- C++ --*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// This header file contains two parts. The first part is the BTF ELF
+// specification in C format, and the second part is the various
+// C++ classes to manipulate the data structure in order to generate
+// the BTF related ELF sections.
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_MC_MCBTFContext_H
+#define LLVM_MC_MCBTFContext_H
+
+#include <linux/types.h>
+
+#define BTF_MAGIC	0xeB9F
+#define BTF_VERSION	1
+
+struct btf_header {
+	__u16	magic;
+	__u8	version;
+	__u8	flags;
+	__u32	hdr_len;
+
+	/* All offsets are in bytes relative to the end of this header */
+	__u32	type_off;	/* offset of type section	*/
+	__u32	type_len;	/* length of type section	*/
+	__u32	str_off;	/* offset of string section	*/
+	__u32	str_len;	/* length of string section	*/
+};
+
+/* Max # of type identifier */
+#define BTF_MAX_TYPE	0x0000ffff
+/* Max offset into the string section */
+#define BTF_MAX_NAME_OFFSET	0x0000ffff
+/* Max # of struct/union/enum members or func args */
+#define BTF_MAX_VLEN	0xffff
+
+struct btf_type {
+	__u32 name_off;
+	/* "info" bits arrangement
+	 * bits  0-15: vlen (e.g. # of struct's members)
+	 * bits 16-23: unused
+	 * bits 24-27: kind (e.g. int, ptr, array...etc)
+	 * bits 28-31: unused
+	 */
+	__u32 info;
+	/* "size" is used by INT, ENUM, STRUCT and UNION.
+	 * "size" tells the size of the type it is describing.
+	 *
+	 * "type" is used by PTR, TYPEDEF, VOLATILE, CONST and RESTRICT.
+	 * "type" is a type_id referring to another type.
+	 */
+	union {
+		__u32 size;
+		__u32 type;
+	};
+};
+
+#define BTF_INFO_KIND(info)	(((info) >> 24) & 0x0f)
+#define BTF_INFO_VLEN(info)	((info) & 0xffff)
+
+#define BTF_KIND_UNKN		0	/* Unknown	*/
+#define BTF_KIND_INT		1	/* Integer	*/
+#define BTF_KIND_PTR		2	/* Pointer	*/
+#define BTF_KIND_ARRAY		3	/* Array	*/
+#define BTF_KIND_STRUCT		4	/* Struct	*/
+#define BTF_KIND_UNION		5	/* Union	*/
+#define BTF_KIND_ENUM		6	/* Enumeration	*/
+#define BTF_KIND_FWD		7	/* Forward	*/
+#define BTF_KIND_TYPEDEF	8	/* Typedef	*/
+#define BTF_KIND_VOLATILE	9	/* Volatile	*/
+#define BTF_KIND_CONST		10	/* Const	*/
+#define BTF_KIND_RESTRICT	11	/* Restrict	*/
+#define BTF_KIND_FUNC		12	/* Function	*/
+#define BTF_KIND_FUNC_PROTO	13	/* Function Prototype	*/
+#define BTF_KIND_MAX		13
+#define NR_BTF_KINDS		14
+
+/* For some specific BTF_KIND, "struct btf_type" is immediately
+ * followed by extra data.
+ */
+
+/* BTF_KIND_INT is followed by a u32 and the following
+ * is the 32 bits arrangement:
+ */
+#define BTF_INT_ENCODING(VAL)	(((VAL) & 0x0f000000) >> 24)
+#define BTF_INT_OFFSET(VAL)	(((VAL  & 0x00ff0000)) >> 16)
+#define BTF_INT_BITS(VAL)	((VAL)  & 0x000000ff)
+
+/* Attributes stored in the BTF_INT_ENCODING */
+#define BTF_INT_SIGNED	(1 << 0)
+#define BTF_INT_CHAR	(1 << 1)
+#define BTF_INT_BOOL	(1 << 2)
+
+/* BTF_KIND_ENUM is followed by multiple "struct btf_enum".
+ * The exact number of btf_enum is stored in the vlen (of the
+ * info in "struct btf_type").
+ */
+struct btf_enum {
+	__u32	name_off;
+	__s32	val;
+};
+
+/* BTF_KIND_ARRAY is followed by one "struct btf_array" */
+struct btf_array {
+	__u32	type;
+	__u32	index_type;
+	__u32	nelems;
+};
+
+/* BTF_KIND_STRUCT and BTF_KIND_UNION are followed
+ * by multiple "struct btf_member".  The exact number
+ * of btf_member is stored in the vlen (of the info in
+ * "struct btf_type").
+ */
+struct btf_member {
+	__u32	name_off;
+	__u32	type;
+	__u32	offset;	/* offset in bits */
+};
+
+/* .BTF.ext section contains func_info and line_info.
+ */
+struct btf_ext_header {
+	__u16	magic;
+	__u8	version;
+	__u8	flags;
+	__u32	hdr_len;
+
+	__u32	func_info_off;
+	__u32	func_info_len;
+	__u32	line_info_off;
+	__u32	line_info_len;
+};
+
+struct bpf_func_info {
+	__u64	insn_offset;
+	__u32	type_id;
+	__u32	:32;
+};
+
+struct btf_sec_func_info {
+	__u32	sec_name_off;
+	__u32	num_func_info;
+	/* struct bpf_func_info func_info[0]; */
+};
+
+struct bpf_line_info {
+	__u64	insn_offset;
+	__u32	file_name_off;
+	__u32	line_off;
+	__u32	line_num;
+	__u32	column_num;
+};
+
+struct btf_sec_line_info {
+	__u32	sec_name_off;
+	__u32	num_line_info;
+	/* struct bpf_line_info line_info[0]; */
+};
+
+namespace llvm {
+
+const char *const btf_kind_str[NR_BTF_KINDS] = {
+	[BTF_KIND_UNKN]		= "UNKNOWN",
+	[BTF_KIND_INT]		= "INT",
+	[BTF_KIND_PTR]		= "PTR",
+	[BTF_KIND_ARRAY]	= "ARRAY",
+	[BTF_KIND_STRUCT]	= "STRUCT",
+	[BTF_KIND_UNION]	= "UNION",
+	[BTF_KIND_ENUM]		= "ENUM",
+	[BTF_KIND_FWD]		= "FWD",
+	[BTF_KIND_TYPEDEF]	= "TYPEDEF",
+	[BTF_KIND_VOLATILE]	= "VOLATILE",
+	[BTF_KIND_CONST]	= "CONST",
+	[BTF_KIND_RESTRICT]	= "RESTRICT",
+	[BTF_KIND_FUNC]		= "FUNC",
+	[BTF_KIND_FUNC_PROTO]	= "FUNC_PROTO",
+};
+
+#include "llvm/ADT/SmallVector.h"
+#include <map>
+
+class MCBTFContext;
+class MCObjectStreamer;
+
+#define BTF_INVALID_ENCODING 0xff
+
+// This is base class of all BTF KIND. It is also used directly
+// by the reference kinds:
+//   BTF_KIND_CONST,  BTF_KIND_PTR,  BTF_KIND_VOLATILE,
+//   BTF_KIND_TYPEDEF, BTF_KIND_RESTRICT, and BTF_KIND_FWD
+class BTFTypeEntry {
+protected:
+  size_t Id;  /* type index in the BTF list, started from 1 */
+  struct btf_type BTFType;
+
+public:
+  BTFTypeEntry(size_t id, struct btf_type &type) :
+    Id(id), BTFType(type) {}
+  unsigned char getKind() { return BTF_INFO_KIND(BTFType.info); }
+  void setId(size_t Id) { this->Id = Id; }
+  size_t getId() { return Id; }
+  void setNameOff(__u32 NameOff) { BTFType.name_off = NameOff; }
+
+  __u32 getTypeIndex() { return BTFType.type; }
+  __u32 getNameOff() { return BTFType.name_off; }
+  virtual size_t getSize() { return sizeof(struct btf_type); }
+  virtual void print(raw_ostream &s, MCBTFContext& BTFContext);
+  virtual void emitData(MCObjectStreamer *MCOS);
+};
+
+// BTF_KIND_INT
+class BTFTypeEntryInt : public BTFTypeEntry {
+  __u32 IntVal;  // encoding, offset, bits
+
+public:
+  BTFTypeEntryInt(size_t id, struct btf_type &type, __u32 intval) :
+    BTFTypeEntry(id, type), IntVal(intval) {}
+  size_t getSize() { return BTFTypeEntry::getSize() + sizeof(__u32); }
+  void print(raw_ostream &s, MCBTFContext& BTFContext);
+  void emitData(MCObjectStreamer *MCOS);
+};
+
+// BTF_KIND_ENUM
+class BTFTypeEntryEnum : public BTFTypeEntry {
+  std::vector<struct btf_enum> EnumValues;
+
+public:
+  BTFTypeEntryEnum(size_t id, struct btf_type &type, std::vector<struct btf_enum> &values) :
+    BTFTypeEntry(id, type), EnumValues(values) {}
+  size_t getSize() {
+    return BTFTypeEntry::getSize() +
+      BTF_INFO_VLEN(BTFType.info) * sizeof(struct btf_enum);
+  }
+  void print(raw_ostream &s, MCBTFContext& BTFContext);
+  void emitData(MCObjectStreamer *MCOS);
+};
+
+// BTF_KIND_ARRAY
+class BTFTypeEntryArray : public BTFTypeEntry {
+  struct btf_array ArrayInfo;
+
+public:
+  BTFTypeEntryArray(size_t id, struct btf_type &type, struct btf_array &arrayinfo) :
+    BTFTypeEntry(id, type), ArrayInfo(arrayinfo) {}
+  size_t getSize() {
+    return BTFTypeEntry::getSize() +  sizeof(struct btf_array);
+  }
+  void print(raw_ostream &s, MCBTFContext& BTFContext);
+  void emitData(MCObjectStreamer *MCOS);
+};
+
+// BTF_KIND_STRUCT and BTF_KIND_UNION
+class BTFTypeEntryStruct : public BTFTypeEntry {
+  std::vector<struct btf_member> Members;
+
+public:
+  BTFTypeEntryStruct(size_t id, struct btf_type &type, std::vector<struct btf_member> &members) :
+    BTFTypeEntry(id, type), Members(members) {}
+  size_t getSize() {
+    return BTFTypeEntry::getSize() +
+      BTF_INFO_VLEN(BTFType.info) * sizeof(struct btf_member);
+  }
+  void print(raw_ostream &s, MCBTFContext& BTFContext);
+  void emitData(MCObjectStreamer *MCOS);
+};
+
+class BTFTypeEntryFunc : public BTFTypeEntry {
+  std::vector<__u32> Parameters;
+
+public:
+  BTFTypeEntryFunc(size_t id, struct btf_type &type, std::vector<__u32> &params) :
+    BTFTypeEntry(id, type), Parameters(params) {}
+  size_t getSize() {
+    return BTFTypeEntry::getSize() +
+      BTF_INFO_VLEN(BTFType.info) * sizeof(__u32);
+  }
+  void print(raw_ostream &s, MCBTFContext& BTFContext);
+  void emitData(MCObjectStreamer *MCOS);
+};
+
+class BTFStringTable {
+  size_t Size;  // total size in bytes
+  std::map<size_t, __u32> OffsetToIdMap;
+
+ public:
+  std::vector<std::string> Table;
+  BTFStringTable() : Size(0) {}
+  size_t addString(std::string S) {
+    size_t Offset = Size;
+    OffsetToIdMap[Offset] = Table.size();
+    Table.push_back(S);
+    Size += S.size() + 1;
+    return Offset;
+  }
+  std::string &getStringAtOffset(size_t Offset) {
+    return Table[OffsetToIdMap[Offset]];
+  }
+  void showTable() {
+    for (auto S : Table)
+      outs() << S << "\n";
+  }
+  size_t getSize() { return Size; }
+};
+
+class BTFFuncInfo  {
+  public:
+    const MCSymbol *Label;
+    unsigned int type_id;
+};
+
+class BTFFuncInfoSection {
+  public:
+    unsigned int secname_off;
+    std::vector<BTFFuncInfo> info;
+};
+
+class BTFLineInfo  {
+  public:
+    MCSymbol *label;
+    unsigned int filename_off;
+    unsigned int line_off;
+    unsigned int line_num;
+    unsigned int column_num;
+};
+
+class BTFLineInfoSection {
+  public:
+    unsigned int secname_off;
+    std::vector<BTFLineInfo> info;
+};
+
+class MCBTFContext {
+  friend class BTFTypeEntry;
+  friend class BTFTypeEntryInt;
+  friend class BTFTypeEntryEnum;
+  friend class BTFTypeEntryArray;
+  friend class BTFTypeEntryStruct;
+  friend class BTFTypeEntryFunc;
+
+public:
+  std::vector<std::unique_ptr<BTFTypeEntry>> TypeEntries;
+  BTFStringTable StringTable;
+  std::vector<BTFFuncInfoSection> FuncInfoTable;
+  std::vector<BTFLineInfoSection> LineInfoTable;
+  void showAll();
+  void emitAll(MCObjectStreamer *MCOS);
+  void emitCommonHeader(MCObjectStreamer *MCOS);
+  void emitBTFSection(MCObjectStreamer *MCOS);
+  void emitBTFExtSection(MCObjectStreamer *MCOS);
+  std::string getTypeName(BTFTypeEntry *TypeEntry);
+  std::string getTypeName(__u32 TypeIndex);
+
+  size_t addString(std::string S) {
+    return StringTable.addString(S);
+  }
+
+  std::string &getStringAtOffset(__u32 Offset) {
+    return StringTable.getStringAtOffset((size_t)Offset);
+  }
+  BTFTypeEntry *getReferredTypeEntry(BTFTypeEntry *TypeEntry);
+  BTFTypeEntry *getMemberTypeEntry(struct btf_member &Member);
+};
+
+}
+#endif

--- a/include/llvm/MC/MCContext.h
+++ b/include/llvm/MC/MCContext.h
@@ -56,6 +56,7 @@ namespace llvm {
   class MCSymbolWasm;
   class SMLoc;
   class SourceMgr;
+  class MCBTFContext;
 
   /// Context object for machine code objects.  This class owns all of the
   /// sections that it creates.
@@ -278,6 +279,9 @@ namespace llvm {
     /// Map of currently defined macros.
     StringMap<MCAsmMacro> MacroMap;
 
+    /// for BTF debug information
+    MCBTFContext *BTFCtx;
+
   public:
     explicit MCContext(const MCAsmInfo *MAI, const MCRegisterInfo *MRI,
                        const MCObjectFileInfo *MOFI,
@@ -285,6 +289,10 @@ namespace llvm {
     MCContext(const MCContext &) = delete;
     MCContext &operator=(const MCContext &) = delete;
     ~MCContext();
+
+    void setBTFContext(MCBTFContext *Ctx) { BTFCtx = Ctx; }
+    void freeBTFContext() { free(BTFCtx); BTFCtx = nullptr; }
+    MCBTFContext *getBTFContext() { return BTFCtx; }
 
     const SourceMgr *getSourceManager() const { return SrcMgr; }
 

--- a/include/llvm/MC/MCObjectFileInfo.h
+++ b/include/llvm/MC/MCObjectFileInfo.h
@@ -207,6 +207,10 @@ protected:
   MCSection *SXDataSection;
   MCSection *GFIDsSection;
 
+  // BTF specific sections.
+  MCSection *BTFSection;
+  MCSection *BTFExtSection;
+
 public:
   void InitMCObjectFileInfo(const Triple &TT, bool PIC, MCContext &ctx,
                             bool LargeCodeModel = false);
@@ -371,6 +375,10 @@ public:
   MCSection *getEHFrameSection() {
     return EHFrameSection;
   }
+
+  // BTF specific sections.
+  MCSection *getBTFSection() const { return BTFSection; }
+  MCSection *getBTFExtSection() const { return BTFExtSection; }
 
   enum Environment { IsMachO, IsELF, IsCOFF, IsWasm };
   Environment getObjectFileType() const { return Env; }

--- a/include/llvm/MC/MCObjectStreamer.h
+++ b/include/llvm/MC/MCObjectStreamer.h
@@ -138,6 +138,7 @@ public:
                                 unsigned PointerSize);
   void EmitDwarfAdvanceFrameAddr(const MCSymbol *LastLabel,
                                  const MCSymbol *Label);
+  void EmitBTFAdvanceLineAddr(const MCSymbol *Label);
   void EmitCVLocDirective(unsigned FunctionId, unsigned FileNo, unsigned Line,
                           unsigned Column, bool PrologueEnd, bool IsStmt,
                           StringRef FileName, SMLoc Loc) override;

--- a/lib/CodeGen/AsmPrinter/CMakeLists.txt
+++ b/lib/CodeGen/AsmPrinter/CMakeLists.txt
@@ -17,6 +17,7 @@ add_llvm_library(LLVMAsmPrinter
   DwarfFile.cpp
   DwarfStringPool.cpp
   DwarfUnit.cpp
+  Dwarf2BTF.cpp
   EHStreamer.cpp
   ErlangGCPrinter.cpp
   OcamlGCPrinter.cpp

--- a/lib/CodeGen/AsmPrinter/Dwarf2BTF.cpp
+++ b/lib/CodeGen/AsmPrinter/Dwarf2BTF.cpp
@@ -1,0 +1,471 @@
+//===- Dwarf2BTF.cpp ------------------------------------------ *- C++ --*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DwarfUnit.h"
+#include "Dwarf2BTF.h"
+#include "llvm/MC/MCBTFContext.h"
+
+namespace llvm {
+
+unsigned char Die2BTFEntry::getDieKind(const DIE & Die) {
+  auto Tag = Die.getTag();
+
+  switch (Tag) {
+    case dwarf::DW_TAG_base_type:
+      if (getBaseTypeEncoding(Die) == BTF_INVALID_ENCODING)
+        return BTF_KIND_UNKN;
+      return BTF_KIND_INT;
+    case dwarf::DW_TAG_const_type:
+      return BTF_KIND_CONST;
+    case dwarf::DW_TAG_pointer_type:
+      return BTF_KIND_PTR;
+    case dwarf::DW_TAG_restrict_type:
+      return BTF_KIND_RESTRICT;
+    case dwarf::DW_TAG_volatile_type:
+      return BTF_KIND_VOLATILE;
+    case dwarf::DW_TAG_structure_type:
+    case dwarf::DW_TAG_class_type:
+      if (Die.findAttribute(dwarf::DW_AT_declaration).getType()
+          != DIEValue::isNone)
+        return BTF_KIND_FWD;
+      else
+        return BTF_KIND_STRUCT;
+    case dwarf::DW_TAG_union_type:
+      if (Die.findAttribute(dwarf::DW_AT_declaration).getType()
+          != DIEValue::isNone)
+        return BTF_KIND_FWD;
+      else
+        return BTF_KIND_UNION;
+    case dwarf::DW_TAG_enumeration_type:
+      return BTF_KIND_ENUM;
+    case dwarf::DW_TAG_array_type:
+      return BTF_KIND_UNKN;
+    case dwarf::DW_TAG_subprogram:
+      return BTF_KIND_FUNC;
+    case dwarf::DW_TAG_subroutine_type:
+      return BTF_KIND_FUNC_PROTO;
+    case dwarf::DW_TAG_compile_unit:
+      return BTF_KIND_UNKN; // TODO: add function support
+    case dwarf::DW_TAG_variable:
+    {
+      auto TypeV = Die.findAttribute(dwarf::DW_AT_type);
+      if (TypeV.getType() == DIEValue::isNone)
+        return BTF_KIND_UNKN;
+      auto &TypeDie = TypeV.getDIEEntry().getEntry();
+      if (TypeDie.getTag() == dwarf::DW_TAG_array_type)
+        return BTF_KIND_ARRAY;
+      else
+        return BTF_KIND_UNKN;
+    }
+    case dwarf::DW_TAG_formal_parameter:
+    case dwarf::DW_TAG_typedef:
+    case dwarf::DW_TAG_inlined_subroutine:
+    case dwarf::DW_TAG_lexical_block:
+      break;
+    default:
+      errs() << "BTF: Unsupported TAG " << dwarf::TagString(Die.getTag())
+             << "\n";
+      break;
+  }
+
+  return BTF_KIND_UNKN;
+}
+
+std::unique_ptr<Die2BTFEntry> Die2BTFEntry::dieToBTFTypeEntry(const DIE &Die) {
+  unsigned char Kind = getDieKind(Die);
+
+  switch (Kind) {
+    case BTF_KIND_INT:
+      return make_unique<Die2BTFEntryInt>(Die);
+    case BTF_KIND_PTR:
+    case BTF_KIND_TYPEDEF:
+    case BTF_KIND_VOLATILE:
+    case BTF_KIND_CONST:
+    case BTF_KIND_RESTRICT:
+      return make_unique<Die2BTFEntry>(Die);
+    case BTF_KIND_ARRAY:
+      return make_unique<Die2BTFEntryArray>(Die);
+    case BTF_KIND_STRUCT:
+    case BTF_KIND_UNION:
+      return make_unique<Die2BTFEntryStruct>(Die);
+    case BTF_KIND_ENUM:
+      return make_unique<Die2BTFEntryEnum>(Die);
+    case BTF_KIND_FUNC:
+    case BTF_KIND_FUNC_PROTO:
+      return make_unique<Die2BTFEntryFunc>(Die);
+    default:
+      break;
+  }
+  return nullptr;
+}
+
+bool Die2BTFEntry::shouldSkipDie(const DIE &Die) {
+  auto Tag = Die.getTag();
+
+  switch (Tag) {
+    case dwarf::DW_TAG_const_type:
+    case dwarf::DW_TAG_pointer_type:
+    case dwarf::DW_TAG_restrict_type:
+    case dwarf::DW_TAG_typedef:
+    case dwarf::DW_TAG_volatile_type:
+    {
+      auto TypeV = Die.findAttribute(dwarf::DW_AT_type);
+      if (TypeV.getType() == DIEValue::isNone) {
+        if (Tag == dwarf::DW_TAG_pointer_type)
+          return true;  // TODO: handle void pointer?
+         errs() << "Tag " << dwarf::TagString(Tag) << " has no type\n";
+        Die.print(errs());
+        return true;
+      }
+      auto &TypeDie = TypeV.getDIEEntry().getEntry();
+      return Die2BTFEntry::shouldSkipDie(TypeDie);
+    }
+    default:
+      return getDieKind(Die) == BTF_KIND_UNKN;
+  }
+  return true;
+}
+unsigned char Die2BTFEntry::getBaseTypeEncoding(const DIE &Die) {
+  auto V = Die.findAttribute(dwarf::DW_AT_encoding);
+
+  if (V.getType() != DIEValue::isInteger)
+    return BTF_INVALID_ENCODING;
+
+  switch (V.getDIEInteger().getValue()) {
+    case dwarf::DW_ATE_boolean:
+      return BTF_INT_BOOL;
+    case dwarf::DW_ATE_signed:
+      return BTF_INT_SIGNED;
+    case dwarf::DW_ATE_signed_char:
+      return BTF_INT_CHAR;
+    case dwarf::DW_ATE_unsigned:
+      return 0;
+    case dwarf::DW_ATE_unsigned_char:
+      return BTF_INT_CHAR;
+    case dwarf::DW_ATE_imaginary_float:
+    case dwarf::DW_ATE_packed_decimal:
+    case dwarf::DW_ATE_numeric_string:
+    case dwarf::DW_ATE_edited:
+    case dwarf::DW_ATE_signed_fixed:
+    case dwarf::DW_ATE_address:
+    case dwarf::DW_ATE_complex_float:
+    case dwarf::DW_ATE_float:
+    default:
+      break;
+  }
+  return BTF_INVALID_ENCODING;
+}
+
+Die2BTFEntry::Die2BTFEntry(const DIE &Die) : Die(Die) {
+  unsigned char kind = getDieKind(Die);
+
+  switch (kind) {
+    case BTF_KIND_CONST:
+    case BTF_KIND_PTR:
+    case BTF_KIND_VOLATILE:
+    case BTF_KIND_TYPEDEF:
+    case BTF_KIND_RESTRICT:
+      break;
+    default:
+      assert("Invalid Die passed into BTFTypeEntry()");
+      break;
+  }
+
+  BTFType.info = (kind & 0xf) << 24;
+}
+
+void Die2BTFEntry::completeData(class Dwarf2BTF &Dwarf2BTF) {
+    auto TypeV = Die.findAttribute(dwarf::DW_AT_type);
+    auto &TypeDie = TypeV.getDIEEntry().getEntry();
+    auto type = Dwarf2BTF.getTypeIndex(TypeDie);
+
+    // reference types doesn't have name
+    BTFType.name_off = 0;
+    BTFType.type = type;
+
+    auto typeEntry = make_unique<BTFTypeEntry>(Id, BTFType);
+    Dwarf2BTF.BTFContext->TypeEntries.push_back(std::move(typeEntry));
+}
+
+Die2BTFEntryInt::Die2BTFEntryInt(const DIE &Die) : Die2BTFEntry(Die) {
+  unsigned char kind = getDieKind(Die);
+
+  switch (kind) {
+    case BTF_KIND_INT:
+      break;
+    default:
+      assert("Invalid Die passed into BTFTypeEntryInt()");
+      break;
+  }
+
+  // handle BTF_INT_ENCODING in IntVal
+  auto Encoding = Die2BTFEntry::getBaseTypeEncoding(Die);
+  assert((Encoding != BTF_INVALID_ENCODING) &&
+         "Invalid Die passed to BTFTypeEntryInt()");
+  __u32 IntVal = (Encoding & 0xf) << 24;
+
+  // handle BTF_INT_OFFSET in IntVal
+  auto V = Die.findAttribute(dwarf::DW_AT_bit_offset);
+  if (V.getType() == DIEValue::isInteger)
+    IntVal |= (V.getDIEInteger().getValue() & 0xff) << 16;
+
+  // get btf_type.size
+  V = Die.findAttribute(dwarf::DW_AT_byte_size);
+  __u32 Size = V.getDIEInteger().getValue() & 0xffffffff;
+
+// handle BTF_INT_BITS in IntVal
+  V = Die.findAttribute(dwarf::DW_AT_bit_size);
+  if (V.getType() == DIEValue::isInteger) {
+    IntVal |= V.getDIEInteger().getValue() & 0xff;
+    IntVal |= (V.getDIEInteger().getValue() & 0xff);
+  } else
+    IntVal |= (Size << 3) & 0xff;
+
+  BTFType.info = BTF_KIND_INT << 24;
+  BTFType.size = Size;
+  this->IntVal = IntVal;
+}
+
+void Die2BTFEntryInt::completeData(class Dwarf2BTF &Dwarf2BTF) {
+    auto NameV = Die.findAttribute(dwarf::DW_AT_name);
+    auto TypeV = Die.findAttribute(dwarf::DW_AT_type);
+    auto Str = NameV.getDIEString().getString();
+
+    BTFType.name_off = Dwarf2BTF.BTFContext->addString(Str);
+
+    auto typeEntry = make_unique<BTFTypeEntryInt>(Id, BTFType, IntVal);
+    Dwarf2BTF.BTFContext->TypeEntries.push_back(std::move(typeEntry));
+}
+
+Die2BTFEntryEnum::Die2BTFEntryEnum(const DIE &Die) : Die2BTFEntry(Die) {
+  // get btf_type.size
+  auto V = Die.findAttribute(dwarf::DW_AT_byte_size);
+  __u32 Size = V.getDIEInteger().getValue() & 0xffffffff;
+
+  int Vlen = 0;
+  for (auto &ChildDie : Die.children())
+    if (ChildDie.getTag() == dwarf::DW_TAG_enumerator)
+      Vlen++;
+
+  BTFType.info = (BTF_KIND_ENUM << 24) | (Vlen & BTF_MAX_VLEN);
+  BTFType.type = Size;
+}
+
+void Die2BTFEntryEnum::completeData(class Dwarf2BTF &Dwarf2BTF) {
+  auto TypeV = Die.findAttribute(dwarf::DW_AT_type);
+  auto NameV = Die.findAttribute(dwarf::DW_AT_name);
+
+  if (NameV.getType() != DIEValue::isNone) {
+    auto Str = NameV.getDIEString().getString();
+    BTFType.name_off = Dwarf2BTF.BTFContext->addString(Str);
+  } else
+    BTFType.name_off = 0;
+
+  for (auto &ChildDie : Die.children()) {
+    struct btf_enum BTFEnum;
+    auto ChildNameV = ChildDie.findAttribute(dwarf::DW_AT_name);
+    auto Str = ChildNameV.getDIEString().getString();
+
+    BTFEnum.name_off = Dwarf2BTF.BTFContext->addString(Str);
+    auto ChildValueV = ChildDie.findAttribute(dwarf::DW_AT_const_value);
+    BTFEnum.val = (__s32)(ChildValueV.getDIEInteger().getValue());
+
+    EnumValues.push_back(BTFEnum);
+  }
+
+  auto typeEntry = make_unique<BTFTypeEntryEnum>(Id, BTFType, EnumValues);
+  Dwarf2BTF.BTFContext->TypeEntries.push_back(std::move(typeEntry));
+}
+
+Die2BTFEntryArray::Die2BTFEntryArray(const DIE &Die) :
+    Die2BTFEntry(Die),
+    ArrayTypeDie(Die.findAttribute(dwarf::DW_AT_type).
+                 getDIEEntry().getEntry()) {
+
+  BTFType.info = (BTF_KIND_ARRAY << 24);
+  BTFType.size = 0;
+}
+
+void Die2BTFEntryArray::completeData(class Dwarf2BTF &Dwarf2BTF) {
+  auto NameV = Die.findAttribute(dwarf::DW_AT_name);
+  auto Str = NameV.getDIEString().getString();
+
+  BTFType.name_off = Dwarf2BTF.BTFContext->addString(Str);
+
+  auto TypeV = ArrayTypeDie.findAttribute(dwarf::DW_AT_type);
+  auto &TypeDie = TypeV.getDIEEntry().getEntry();
+
+  ArrayInfo.type = Dwarf2BTF.getTypeIndex(TypeDie);
+
+  for (auto &ChildDie : ArrayTypeDie.children()) {
+    if (ChildDie.getTag() == dwarf::DW_TAG_subrange_type) {
+      auto CountV = ChildDie.findAttribute(dwarf::DW_AT_count);
+      ArrayInfo.nelems =
+        (__u32)(CountV.getDIEInteger().getValue());
+
+      TypeV = ChildDie.findAttribute(dwarf::DW_AT_type);
+      auto &TypeDie = TypeV.getDIEEntry().getEntry();
+      ArrayInfo.index_type = Dwarf2BTF.getTypeIndex(TypeDie);
+      break;
+    }
+  }
+
+  auto typeEntry = make_unique<BTFTypeEntryArray>(Id, BTFType, ArrayInfo);
+  Dwarf2BTF.BTFContext->TypeEntries.push_back(std::move(typeEntry));
+}
+
+Die2BTFEntryStruct::Die2BTFEntryStruct(const DIE &Die) : Die2BTFEntry(Die) {
+  // get btf_type.size
+  auto V = Die.findAttribute(dwarf::DW_AT_byte_size);
+  __u32 Size = V.getDIEInteger().getValue() & 0xffffffff;
+  auto Kind = Die2BTFEntry::getDieKind(Die);
+
+  int Vlen = 0;
+  for (auto &ChildDie : Die.children())
+    if (ChildDie.getTag() == dwarf::DW_TAG_member)
+      Vlen++;
+
+  BTFType.size = Size;
+  BTFType.info = (Kind << 24) | (Vlen & BTF_MAX_VLEN);
+}
+
+void Die2BTFEntryStruct::completeData(class Dwarf2BTF &Dwarf2BTF) {
+  auto NameV = Die.findAttribute(dwarf::DW_AT_name);
+
+  if (NameV.getType() != DIEValue::isNone) {
+    auto Str = NameV.getDIEString().getString();
+    BTFType.name_off = Dwarf2BTF.BTFContext->addString(Str);
+  } else
+    BTFType.name_off = 0;
+
+
+  for (auto &ChildDie : Die.children()) {
+    if (ChildDie.getTag() != dwarf::DW_TAG_member)
+      continue;
+
+    struct btf_member BTFMember;
+    auto ChildNameV = ChildDie.findAttribute(dwarf::DW_AT_name);
+
+    if (ChildNameV.getType() != DIEValue::isNone) {
+      auto Str = ChildNameV.getDIEString().getString();
+      BTFMember.name_off = Dwarf2BTF.BTFContext->addString(Str);
+    } else
+      BTFMember.name_off = 0;
+
+    auto TypeV = ChildDie.findAttribute(dwarf::DW_AT_type);
+    auto &TypeDie = TypeV.getDIEEntry().getEntry();
+    BTFMember.type = Dwarf2BTF.getTypeIndex(TypeDie);
+
+    auto OffsetV = ChildDie.findAttribute(dwarf::DW_AT_bit_offset);
+    BTFMember.offset = (OffsetV.getType() == DIEValue::isInteger) ?
+      OffsetV.getDIEInteger().getValue() : 0;
+
+    Members.push_back(BTFMember);
+  }
+
+  auto typeEntry = make_unique<BTFTypeEntryStruct>(Id, BTFType, Members);
+  Dwarf2BTF.BTFContext->TypeEntries.push_back(std::move(typeEntry));
+}
+
+Die2BTFEntryFunc::Die2BTFEntryFunc(const DIE &Die) : Die2BTFEntry(Die) {
+  auto Kind = Die2BTFEntry::getDieKind(Die);
+
+  int Vlen = 0;
+  for (auto &ChildDie : Die.children())
+    if (ChildDie.getTag() == dwarf::DW_TAG_formal_parameter)
+      Vlen++;
+
+  BTFType.size = 0;
+  BTFType.info = (Kind << 24) | (Vlen & BTF_MAX_VLEN);
+}
+
+void Die2BTFEntryFunc::completeData(class Dwarf2BTF &Dwarf2BTF) {
+  auto NameV = Die.findAttribute(dwarf::DW_AT_name);
+  if (NameV.getType() == DIEValue::isNone) {
+    auto TypeV = Die.findAttribute(dwarf::DW_AT_type);
+    if (TypeV.getType() == DIEValue::isNone)
+      return;
+    NameV = TypeV.getDIEEntry().getEntry().findAttribute(dwarf::DW_AT_name);
+    if (NameV.getType() == DIEValue::isNone)
+      return;
+  }
+  auto Str = NameV.getDIEString().getString();
+  BTFType.name_off = Dwarf2BTF.BTFContext->addString(Str);
+
+  for (auto &ChildDie : Die.children()) {
+    if (ChildDie.getTag() != dwarf::DW_TAG_formal_parameter)
+      continue;
+
+    auto TypeV = ChildDie.findAttribute(dwarf::DW_AT_type);
+    auto &TypeDie = TypeV.getDIEEntry().getEntry();
+    Parameters.push_back(Dwarf2BTF.getTypeIndex(TypeDie));
+  }
+
+  auto typeEntry = make_unique<BTFTypeEntryFunc>(Id, BTFType, Parameters);
+  Dwarf2BTF.BTFContext->TypeEntries.push_back(std::move(typeEntry));
+
+  if (BTF_INFO_KIND(BTFType.info) == BTF_KIND_FUNC) {
+    const MCSymbol *Label = nullptr;
+    for (const auto &V : Die.values()) {
+      if (V.getAttribute() != dwarf::DW_AT_low_pc)
+        continue;
+      Label = V.getDIELabel().getValue();
+      break;
+    }
+
+    if (Label) {
+      BTFFuncInfo funcInfo;
+      funcInfo.Label = Label;
+      funcInfo.type_id = Id;
+      BTFFuncInfoSection funcInfoSec;
+      funcInfoSec.info.push_back(std::move(funcInfo));
+      Dwarf2BTF.BTFContext->FuncInfoTable.push_back(std::move(funcInfoSec));
+    }
+  }
+}
+
+void Dwarf2BTF::addTypeEntry(const DIE &Die) {
+  auto Tag = Die.getTag();
+
+  if (Tag == dwarf::DW_TAG_subprogram || Tag == dwarf::DW_TAG_compile_unit)
+    for (auto &ChildDie : Die.children())
+      addTypeEntry(ChildDie);
+  if (Die2BTFEntry::shouldSkipDie(Die))
+    return;
+  auto Kind = Die2BTFEntry::getDieKind(Die);
+  if (Kind != BTF_KIND_UNKN) {
+    auto TypeEntry = Die2BTFEntry::dieToBTFTypeEntry(Die);
+    if (TypeEntry != nullptr) {
+      TypeEntry->setId(TypeEntries.size());
+      DieToIdMap[const_cast<DIE*>(&Die)] = TypeEntry->getId();
+      TypeEntries.push_back(std::move(TypeEntry));
+    }
+  }
+}
+
+void Dwarf2BTF::completeData() {
+  BTFContext->StringTable.addString("\0");
+
+  for (auto &TypeEntry : TypeEntries)
+    TypeEntry->completeData(*this);
+}
+
+void Dwarf2BTF::addDwarfCU(DwarfUnit *TheU) {
+  DIE &CuDie = TheU->getUnitDie();
+
+  assert((CuDie.getTag() == dwarf::DW_TAG_compile_unit) &&
+         "Not a compile unit");
+  addTypeEntry(CuDie);
+}
+
+void Dwarf2BTF::finish() {
+  completeData();
+}
+
+}

--- a/lib/CodeGen/AsmPrinter/Dwarf2BTF.h
+++ b/lib/CodeGen/AsmPrinter/Dwarf2BTF.h
@@ -1,0 +1,125 @@
+//===- Dwarf2BTF.h -------------------------------------------- *- C++ --*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIB_CODEGEN_ASMPRINTER_DWARF2BTF_H
+#define LLVM_LIB_CODEGEN_ASMPRINTER_DWARF2BTF_H
+
+#include "DwarfUnit.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/CodeGen/AsmPrinter.h"
+#include "llvm/CodeGen/DIE.h"
+#include "llvm/MC/MCBTFContext.h"
+#include <map>
+
+namespace llvm {
+
+class Dwarf2BTF;
+
+class Die2BTFEntry {
+protected:
+  const DIE &Die;
+  size_t Id;  /* type index in the BTF list, started from 1 */
+  struct btf_type BTFType;
+
+public:
+  // return desired BTF_KIND for the Die, return BTF_KIND_UNKN for
+  // invalid/unsupported Die
+  static unsigned char getDieKind(const DIE &Die);
+
+  // Return proper BTF_INT_ENCODING of a basetype.
+  // Return BTF_INVALID_ENCODING for unsupported (float, etc.)
+  static unsigned char getBaseTypeEncoding(const DIE &Die);
+
+  // Return whether this Die should be skipped.
+  // We current skip:
+  //  1. Unsupported data type (float) and references to unsupported types
+  //  2. Non-array variable names
+  static bool shouldSkipDie(const DIE &Die);
+
+  static std::unique_ptr<Die2BTFEntry> dieToBTFTypeEntry(const DIE &Die);
+
+  Die2BTFEntry(const DIE &Die);
+  void setId(size_t Id) { this->Id = Id; }
+  size_t getId() { return Id; }
+  virtual void completeData(class Dwarf2BTF &Dwarf2BTF);
+};
+
+// BTF_KIND_INT
+class Die2BTFEntryInt : public Die2BTFEntry {
+  __u32 IntVal;  // encoding, offset, bits
+
+public:
+  Die2BTFEntryInt(const DIE &Die);
+  void completeData(class Dwarf2BTF &Dwarf2BTF);
+};
+
+// BTF_KIND_ENUM
+class Die2BTFEntryEnum : public Die2BTFEntry {
+  std::vector<struct btf_enum> EnumValues;
+
+public:
+  Die2BTFEntryEnum(const DIE &Die);
+  void completeData(class Dwarf2BTF &Dwarf2BTF);
+};
+
+// BTF_KIND_ARRAY
+class Die2BTFEntryArray : public Die2BTFEntry {
+  DIE &ArrayTypeDie;   // use Die for DW_TAG_variable
+                       // use ArrayTypeDie for DW_TAG_array_type
+  struct btf_array ArrayInfo;
+
+public:
+  Die2BTFEntryArray(const DIE &Die);
+  void completeData(class Dwarf2BTF &Dwarf2BTF);
+};
+
+// BTF_KIND_STRUCT and BTF_KIND_UNION
+class Die2BTFEntryStruct : public Die2BTFEntry {
+  std::vector<struct btf_member> Members;
+
+public:
+  Die2BTFEntryStruct(const DIE &Die);
+  void completeData(class Dwarf2BTF &Dwarf2BTF);
+};
+
+class Die2BTFEntryFunc : public Die2BTFEntry {
+  std::vector<__u32> Parameters;
+
+public:
+  Die2BTFEntryFunc(const DIE &Die);
+  void completeData(class Dwarf2BTF &Dwarf2BTF);
+};
+
+class Dwarf2BTF {
+  std::vector<std::unique_ptr<Die2BTFEntry>> TypeEntries;
+  std::map<DIE*, size_t> DieToIdMap;
+
+public:
+  MCBTFContext *BTFContext;
+  Dwarf2BTF() { BTFContext = new MCBTFContext(); }
+  void addDwarfCU(DwarfUnit *TheU);
+  void finish();
+  MCBTFContext *getBTFContext() { return BTFContext; }
+  __u32 getTypeIndex(DIE &Die) {
+    DIE *DiePtr = const_cast<DIE*>(&Die);
+    assert((DieToIdMap.find(DiePtr) != DieToIdMap.end()) &&
+           "Die not added to in the BTFContext");
+    return DieToIdMap[DiePtr] + 1;
+  }
+
+private:
+  void addTypeEntry(const DIE &Die);
+  bool alreadyAdded(DIE &Die) {
+    return DieToIdMap.find(const_cast<DIE*>(&Die)) != DieToIdMap.end();
+  }
+
+  void completeData();
+};
+
+}
+#endif

--- a/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -913,6 +913,10 @@ void DwarfDebug::endModule() {
   // Emit the pubnames and pubtypes sections if requested.
   emitDebugPubSections();
 
+  const Triple &TT = Asm->TM.getTargetTriple();
+  if (TT.getArch() == Triple::bpfel || TT.getArch() == Triple::bpfeb)
+    emitBTFSection();
+
   // clean up.
   // FIXME: AbstractVariables.clear();
 }
@@ -2387,6 +2391,12 @@ MCDwarfDwoLineTable *DwarfDebug::getDwoLineTable(const DwarfCompileUnit &CU) {
       DIUnit->getDirectory(), DIUnit->getFilename(),
       CU.getMD5AsBytes(DIUnit->getFile()), DIUnit->getSource());
   return &SplitTypeUnitFileTable;
+}
+
+void DwarfDebug::emitBTFSection() {
+  DwarfFile &Holder = useSplitDwarf() ? SkeletonHolder : InfoHolder;
+
+  Holder.emitBTFSection();
 }
 
 uint64_t DwarfDebug::makeTypeSignature(StringRef Identifier) {

--- a/lib/CodeGen/AsmPrinter/DwarfDebug.h
+++ b/lib/CodeGen/AsmPrinter/DwarfDebug.h
@@ -563,6 +563,9 @@ class DwarfDebug : public DebugHandlerBase {
   /// Emit the reference to the section.
   void emitSectionReference(const DwarfCompileUnit &CU);
 
+  // Emit the BTF sections
+  void emitBTFSection();
+
 protected:
   /// Gather pre-function debug information.
   void beginFunctionImpl(const MachineFunction *MF) override;

--- a/lib/CodeGen/AsmPrinter/DwarfFile.cpp
+++ b/lib/CodeGen/AsmPrinter/DwarfFile.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Dwarf2BTF.h"
 #include "DwarfFile.h"
 #include "DwarfCompileUnit.h"
 #include "DwarfDebug.h"
@@ -15,6 +16,8 @@
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/CodeGen/DIE.h"
 #include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/MC/MCBTFContext.h"
+#include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCStreamer.h"
 #include <algorithm>
 #include <cstdint>
@@ -86,6 +89,16 @@ void DwarfFile::emitAbbrevs(MCSection *Section) { Abbrevs.Emit(Asm, Section); }
 void DwarfFile::emitStrings(MCSection *StrSection, MCSection *OffsetSection,
                             bool UseRelativeOffsets) {
   StrPool.emit(*Asm, StrSection, OffsetSection, UseRelativeOffsets);
+}
+
+void DwarfFile::emitBTFSection() {
+  Dwarf2BTF Dwarf2BTF;
+  for (auto &TheU : CUs) {
+    // TheU->getUnitDie().print(outs());
+    Dwarf2BTF.addDwarfCU(TheU.get());
+  }
+  Dwarf2BTF.finish();
+  Asm->OutContext.setBTFContext(Dwarf2BTF.getBTFContext());
 }
 
 bool DwarfFile::addScopeVariable(LexicalScope *LS, DbgVariable *Var) {

--- a/lib/CodeGen/AsmPrinter/DwarfFile.h
+++ b/lib/CodeGen/AsmPrinter/DwarfFile.h
@@ -114,6 +114,9 @@ public:
   void emitStrings(MCSection *StrSection, MCSection *OffsetSection = nullptr,
                    bool UseRelativeOffsets = false);
 
+  // Emit all data for the BTF section
+  void emitBTFSection();
+
   /// Returns the string pool.
   DwarfStringPool &getStringPool() { return StrPool; }
 

--- a/lib/MC/CMakeLists.txt
+++ b/lib/MC/CMakeLists.txt
@@ -10,11 +10,13 @@ add_llvm_library(LLVMMC
   MCAsmMacro.cpp
   MCAsmStreamer.cpp
   MCAssembler.cpp
+  MCBTFContext.cpp
   MCCodeEmitter.cpp
   MCCodePadder.cpp
   MCCodeView.cpp
   MCContext.cpp
   MCDwarf.cpp
+  MCDwarf2BTF.cpp
   MCELFObjectTargetWriter.cpp
   MCELFStreamer.cpp
   MCExpr.cpp

--- a/lib/MC/MCBTFContext.cpp
+++ b/lib/MC/MCBTFContext.cpp
@@ -1,0 +1,280 @@
+
+#include "llvm/MC/MCContext.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/BinaryFormat/COFF.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCBTFContext.h"
+#include "llvm/MC/MCCodeView.h"
+#include "llvm/MC/MCDwarf.h"
+#include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCFragment.h"
+#include "llvm/MC/MCLabel.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCObjectStreamer.h"
+#include "llvm/MC/MCSectionCOFF.h"
+#include "llvm/MC/MCSectionELF.h"
+#include "llvm/MC/MCSectionMachO.h"
+#include "llvm/MC/MCSectionWasm.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCSymbolCOFF.h"
+#include "llvm/MC/MCSymbolELF.h"
+#include "llvm/MC/MCSymbolMachO.h"
+#include "llvm/MC/MCSymbolWasm.h"
+#include "llvm/MC/SectionKind.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Signals.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+#include <cassert>
+#include <cstdlib>
+#include <tuple>
+#include <utility>
+
+using namespace llvm;
+
+void MCBTFContext::showAll() {
+  for (size_t i = 0; i < TypeEntries.size(); i++) {
+    auto TypeEntry = TypeEntries[i].get();
+    TypeEntry->print(outs(), *this);
+    outs() << "\n\n";
+  }
+  StringTable.showTable();
+}
+
+void MCBTFContext::emitCommonHeader(MCObjectStreamer *MCOS) {
+  MCOS->EmitIntValue(BTF_MAGIC, 2);
+  MCOS->EmitIntValue(BTF_VERSION, 1);
+  MCOS->EmitIntValue(0, 1);
+}
+
+void MCBTFContext::emitBTFSection(MCObjectStreamer *MCOS) {
+  MCContext &context = MCOS->getContext();
+  MCOS->SwitchSection(context.getObjectFileInfo()->getBTFSection());
+
+  // emit header
+  emitCommonHeader(MCOS);
+  MCOS->EmitIntValue(sizeof(struct btf_header), 4);
+
+  uint32_t type_len = 0, str_len;
+  for (auto &TypeEntry : TypeEntries)
+    type_len += TypeEntry->getSize();
+  str_len = StringTable.getSize();
+
+  MCOS->EmitIntValue(0, 4);
+  MCOS->EmitIntValue(type_len, 4);
+  MCOS->EmitIntValue(type_len, 4);
+  MCOS->EmitIntValue(str_len, 4);
+
+  // emit type table
+  for (auto &TypeEntry: TypeEntries)
+    TypeEntry->emitData(MCOS);
+
+  // emit string table
+  for (auto &S : StringTable.Table) {
+    for (auto C : S)
+      MCOS->EmitIntValue(C, 1);
+    MCOS->EmitIntValue('\0', 1);
+  }
+}
+
+void MCBTFContext::emitBTFExtSection(MCObjectStreamer *MCOS) {
+  MCContext &context = MCOS->getContext();
+  MCOS->SwitchSection(context.getObjectFileInfo()->getBTFExtSection());
+
+  // emit header
+  emitCommonHeader(MCOS);
+  MCOS->EmitIntValue(sizeof(struct btf_ext_header), 4);
+
+  uint32_t func_len = 0, line_len = 0;
+  for (auto &FuncSec : FuncInfoTable) {
+    func_len += sizeof(struct btf_sec_func_info);
+    func_len += FuncSec.info.size() * sizeof(struct bpf_func_info);
+  }
+  for (auto &LineSec : LineInfoTable) {
+    line_len += sizeof(struct btf_sec_line_info);
+    line_len += LineSec.info.size() * sizeof(struct bpf_line_info);
+  }
+
+  MCOS->EmitIntValue(0, 4);
+  MCOS->EmitIntValue(func_len, 4);
+  MCOS->EmitIntValue(func_len, 4);
+  MCOS->EmitIntValue(line_len, 4);
+
+  // emit func_info table
+  for (const auto &SecTable : FuncInfoTable) {
+    MCOS->EmitIntValue(SecTable.secname_off, 4);
+    MCOS->EmitIntValue(SecTable.info.size(), 4);
+    for (const auto &FuncInfo : SecTable.info) {
+      MCOS->EmitBTFAdvanceLineAddr(FuncInfo.Label);
+      MCOS->EmitIntValue(FuncInfo.type_id, 4);
+      MCOS->EmitIntValue(0, 4);
+    }
+  }
+
+  // emit line_info table
+  for (const auto &SecTable : LineInfoTable) {
+    MCOS->EmitIntValue(SecTable.secname_off, 4);
+    MCOS->EmitIntValue(SecTable.info.size(), 4);
+    for (const auto &LineInfo : SecTable.info) {
+      MCOS->EmitBTFAdvanceLineAddr(LineInfo.label);
+      MCOS->EmitIntValue(LineInfo.filename_off, 4);
+      MCOS->EmitIntValue(LineInfo.line_off, 4);
+      MCOS->EmitIntValue(LineInfo.line_num, 4);
+      MCOS->EmitIntValue(LineInfo.column_num, 4);
+    }
+  }
+}
+
+void MCBTFContext::emitAll(MCObjectStreamer *MCOS) {
+  emitBTFSection(MCOS);
+  emitBTFExtSection(MCOS);
+}
+
+BTFTypeEntry *MCBTFContext::getReferredTypeEntry(BTFTypeEntry *TypeEntry) {
+  if (TypeEntry->getTypeIndex() == 0)
+    return nullptr;
+
+  return TypeEntries[TypeEntry->getTypeIndex() - 1].get();
+}
+
+BTFTypeEntry *MCBTFContext::getMemberTypeEntry(struct btf_member &Member) {
+  if (Member.type == 0)
+    return nullptr;
+  return TypeEntries[Member.type - 1].get();
+}
+
+std::string MCBTFContext::getTypeName(BTFTypeEntry *TypeEntry) {
+  if (!TypeEntry)
+    return "UNKNOWN";
+  int Kind = TypeEntry->getKind();
+   switch (Kind) {
+    case BTF_KIND_INT:
+    case BTF_KIND_STRUCT:
+    case BTF_KIND_UNION:
+    case BTF_KIND_ARRAY:
+    case BTF_KIND_FUNC:
+      return StringTable.getStringAtOffset(TypeEntry->getNameOff());
+    case BTF_KIND_ENUM:
+      return "enum " + StringTable.getStringAtOffset(TypeEntry->getNameOff());
+    case BTF_KIND_CONST:
+      return "const " + getTypeName(getReferredTypeEntry(TypeEntry));
+    case BTF_KIND_PTR:
+      return "ptr " + getTypeName(getReferredTypeEntry(TypeEntry));
+    case BTF_KIND_VOLATILE:
+      return "volatile " + getTypeName(getReferredTypeEntry(TypeEntry));
+    case BTF_KIND_TYPEDEF:
+      return "typedef " + getTypeName(getReferredTypeEntry(TypeEntry));
+    case BTF_KIND_RESTRICT:
+      return "restrict " + getTypeName(getReferredTypeEntry(TypeEntry));
+    default:
+      break;
+  }
+  return "";
+}
+
+std::string MCBTFContext::getTypeName(__u32 TypeIndex) {
+  if (TypeIndex == 0)
+    return "";
+  return getTypeName(TypeEntries[TypeIndex - 1].get());
+}
+
+void BTFTypeEntry::print(raw_ostream &s, MCBTFContext& MCBTFContext) {
+  s << "printing kind "
+    << btf_kind_str[BTF_INFO_KIND(BTFType.info)] << "\n";
+   s << "\tname: " << MCBTFContext.getTypeName(this) << "\n";
+  s << "\tname_off: " << BTFType.name_off << "\n";
+  s << "\tinfo: " << format("0x%08lx", BTFType.info) << "\n";
+  s << "\tsize/type: " << format("0x%08lx", BTFType.size) << "\n";
+}
+
+void BTFTypeEntry::emitData(MCObjectStreamer *MCOS) {
+  MCOS->EmitIntValue(BTFType.name_off, 4);
+  MCOS->EmitIntValue(BTFType.info, 4);
+  MCOS->EmitIntValue(BTFType.size, 4);
+}
+
+void BTFTypeEntryInt::print(raw_ostream &s, MCBTFContext& MCBTFContext) {
+  BTFTypeEntry::print(s, MCBTFContext);
+   s << "\tdesc: " << format("0x%08lx", IntVal) << "\n";
+}
+
+void BTFTypeEntryInt::emitData(MCObjectStreamer *MCOS) {
+  BTFTypeEntry::emitData(MCOS);
+  MCOS->EmitIntValue(IntVal, 4);
+}
+
+void BTFTypeEntryEnum::print(raw_ostream &s, MCBTFContext& MCBTFContext) {
+  BTFTypeEntry::print(s, MCBTFContext);
+   for (size_t i = 0; i < BTF_INFO_VLEN(BTFType.info); i++) {
+    auto &EnumValue = EnumValues[i];
+    s << "\tSymbol: " << MCBTFContext.getStringAtOffset(EnumValue.name_off)
+      << " of value " << EnumValue.val
+      << "\n";
+  }
+}
+
+void BTFTypeEntryEnum::emitData(MCObjectStreamer *MCOS) {
+  BTFTypeEntry::emitData(MCOS);
+  for (auto &EnumValue : EnumValues) {
+    MCOS->EmitIntValue(EnumValue.name_off, 4);
+    MCOS->EmitIntValue(EnumValue.val, 4);
+  }
+}
+
+void BTFTypeEntryArray::print(raw_ostream &s, MCBTFContext& MCBTFContext) {
+  BTFTypeEntry::print(s, MCBTFContext);
+  s << "\tElement type: " << format("0x%08lx", ArrayInfo.type) << "\n";
+  s << "\tndex type: " << format("0x%08lx", ArrayInfo.index_type) << "\n";
+  s << "\t# of element: " << ArrayInfo.nelems << "\n";
+}
+
+void BTFTypeEntryArray::emitData(MCObjectStreamer *MCOS) {
+  BTFTypeEntry::emitData(MCOS);
+  MCOS->EmitIntValue(ArrayInfo.type, 4);
+  MCOS->EmitIntValue(ArrayInfo.index_type, 4);
+  MCOS->EmitIntValue(ArrayInfo.nelems, 4);
+}
+
+void BTFTypeEntryStruct::print(raw_ostream &s, MCBTFContext& MCBTFContext) {
+  BTFTypeEntry::print(s, MCBTFContext);
+   for (size_t i = 0; i < BTF_INFO_VLEN(BTFType.info); i++) {
+    auto &Member = Members[i];
+    s << "\tMember: " << MCBTFContext.getStringAtOffset(Member.name_off)
+      << " of type: "
+      << MCBTFContext.getTypeName(MCBTFContext.getMemberTypeEntry(Member))
+      << " (" << Member.type << ")\n";
+  }
+}
+
+void BTFTypeEntryStruct::emitData(MCObjectStreamer *MCOS) {
+  BTFTypeEntry::emitData(MCOS);
+  for (auto &Member : Members) {
+    MCOS->EmitIntValue(Member.name_off, 4);
+    MCOS->EmitIntValue(Member.type, 4);
+    MCOS->EmitIntValue(Member.offset, 4);
+  }
+}
+
+void BTFTypeEntryFunc::print(raw_ostream &s, MCBTFContext& MCBTFContext) {
+  BTFTypeEntry::print(s, MCBTFContext);
+   for (size_t i = 0; i < BTF_INFO_VLEN(BTFType.info); i++) {
+    auto Parameter = Parameters[i];
+    s << "\tParameter of type: " << MCBTFContext.getTypeName(Parameter) << "\n";
+  }
+}
+
+void BTFTypeEntryFunc::emitData(MCObjectStreamer *MCOS) {
+  BTFTypeEntry::emitData(MCOS);
+  for (auto &Parameter: Parameters)
+    MCOS->EmitIntValue(Parameter, 4);
+}

--- a/lib/MC/MCContext.cpp
+++ b/lib/MC/MCContext.cpp
@@ -17,6 +17,7 @@
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCBTFContext.h"
 #include "llvm/MC/MCCodeView.h"
 #include "llvm/MC/MCDwarf.h"
 #include "llvm/MC/MCExpr.h"
@@ -60,7 +61,7 @@ MCContext::MCContext(const MCAsmInfo *mai, const MCRegisterInfo *mri,
     : SrcMgr(mgr), InlineSrcMgr(nullptr), MAI(mai), MRI(mri), MOFI(mofi),
       Symbols(Allocator), UsedNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0),
-      AutoReset(DoAutoReset) {
+      AutoReset(DoAutoReset), BTFCtx(nullptr) {
   SecureLogFile = AsSecureLogFileName;
 
   if (SrcMgr && SrcMgr->getNumBuffers())
@@ -114,6 +115,7 @@ void MCContext::reset() {
   GenDwarfFileNumber = 0;
 
   HadError = false;
+  freeBTFContext();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/MC/MCDwarf2BTF.cpp
+++ b/lib/MC/MCDwarf2BTF.cpp
@@ -1,0 +1,101 @@
+
+
+#include "MCDwarf2BTF.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCObjectStreamer.h"
+#include "llvm/MC/MCSection.h"
+#include "llvm/MC/MCSectionELF.h"
+#include "llvm/MC/MCBTFContext.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/EndianStream.h"
+#include <fstream>
+
+using namespace llvm;
+
+void MCDwarf2BTF::addFiles(MCObjectStreamer *MCOS, std::string &FileName,
+  std::vector<FileContent> &Files) {
+  std::vector<std::string> Content;
+
+  std::ifstream inputfile(FileName);
+  std::string line;
+  Content.push_back(line); // line 0 for empty string
+  while (std::getline(inputfile, line))
+    Content.push_back(line);
+
+  Files.push_back(FileContent(FileName, Content));
+}
+
+void MCDwarf2BTF::addLines(MCObjectStreamer *MCOS, StringRef &SectionName,
+  std::vector<FileContent> &Files,
+  const MCLineSection::MCDwarfLineEntryCollection &LineEntries) {
+  MCContext &context = MCOS->getContext();
+  MCBTFContext *BTFCxt = context.getBTFContext();
+
+  std::vector<BTFLineInfoSection> &LineInfoTable = BTFCxt->LineInfoTable;
+  BTFLineInfoSection InfoSec;
+
+  InfoSec.secname_off = BTFCxt->StringTable.addString(SectionName.str());
+
+  for (const MCDwarfLineEntry &LineEntry : LineEntries) {
+    BTFLineInfo LineInfo;
+    unsigned FileNum = LineEntry.getFileNum();
+    unsigned Line = LineEntry.getLine();
+
+    LineInfo.label = LineEntry.getLabel();
+    if (FileNum < Files.size()) {
+      LineInfo.filename_off = BTFCxt->StringTable.addString(Files[FileNum].first);
+      if (Line < Files[FileNum].second.size())
+        LineInfo.line_off = BTFCxt->StringTable.addString(Files[FileNum].second[Line]);
+      else
+        LineInfo.line_off = 0;
+    } else {
+      LineInfo.filename_off = 0;
+      LineInfo.line_off = 0;
+    }
+    LineInfo.line_num = Line;
+    LineInfo.column_num = LineEntry.getColumn();
+    InfoSec.info.push_back(std::move(LineInfo));
+  }
+  LineInfoTable.push_back(std::move(InfoSec));
+}
+
+void MCDwarf2BTF::addDwarfLineInfo(MCObjectStreamer *MCOS) {
+  MCContext &context = MCOS->getContext();
+  // no need for the rest if no type information
+  if (context.getBTFContext() == nullptr)
+    return;
+
+  auto &LineTables = context.getMCDwarfLineTables();
+  if (LineTables.empty())
+    return;
+
+
+  for (const auto &CUIDTablePair : LineTables) {
+    std::vector<std::string> Dirs;
+    std::vector<FileContent> Files;
+
+    for (auto &Dir : CUIDTablePair.second.getMCDwarfDirs())
+      Dirs.push_back(Dir);
+    for (auto &File : CUIDTablePair.second.getMCDwarfFiles()) {
+      std::string FileName;
+      if (File.DirIndex == 0)
+        FileName = File.Name;
+      else
+        FileName = Dirs[File.DirIndex - 1] + "/" + File.Name;
+      MCDwarf2BTF::addFiles(MCOS, FileName, Files);
+    }
+    for (const auto &LineSec: CUIDTablePair.second.getMCLineSections().getMCLineEntries()) {
+      MCSection *Section = LineSec.first;
+      const MCLineSection::MCDwarfLineEntryCollection &LineEntries = LineSec.second;
+
+      StringRef SectionName;
+      if (MCSectionELF *SectionELF = dyn_cast<MCSectionELF>(Section))
+        SectionName = SectionELF->getSectionName();
+      else
+        return;
+      MCDwarf2BTF::addLines(MCOS, SectionName, Files, LineEntries);
+    }
+  }
+}

--- a/lib/MC/MCDwarf2BTF.h
+++ b/lib/MC/MCDwarf2BTF.h
@@ -1,0 +1,29 @@
+//===- MCDwarf2BTF.h ------------------------------------------ *- C++ --*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIB_MC_MCDWARF2BTF_H
+#define LLVM_LIB_MC_MCDWARF2BTF_H
+
+#include "llvm/MC/MCDwarf.h"
+
+namespace llvm {
+
+using FileContent = std::pair<std::string, std::vector<std::string>>;
+
+class MCDwarf2BTF {
+public:
+  static void addFiles(MCObjectStreamer *MCOS, std::string &FileName,
+    std::vector<FileContent> &Files);
+  static void addLines(MCObjectStreamer *MCOS, StringRef &SectionName,
+    std::vector<FileContent> &Files,
+    const MCLineSection::MCDwarfLineEntryCollection &LineEntries);
+  static void addDwarfLineInfo(MCObjectStreamer *MCOS);
+};
+
+}
+#endif

--- a/lib/MC/MCObjectFileInfo.cpp
+++ b/lib/MC/MCObjectFileInfo.cpp
@@ -468,6 +468,9 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
       Ctx->getELFSection(".eh_frame", EHSectionType, EHSectionFlags);
 
   StackSizesSection = Ctx->getELFSection(".stack_sizes", ELF::SHT_PROGBITS, 0);
+
+  BTFSection = Ctx->getELFSection(".BTF", ELF::SHT_PROGBITS, 0);
+  BTFExtSection = Ctx->getELFSection(".BTF.ext", ELF::SHT_PROGBITS, 0);
 }
 
 void MCObjectFileInfo::initCOFFMCObjectFileInfo(const Triple &T) {


### PR DESCRIPTION
BTF is the debug format for BPF, which contains
two parts:
  .BTF contains all the type and string information, and
  .BTF.ext contains the func_info and line_info.

The type and func_info are gathered during CodeGen/AsmPrinter
where dwarf debug_info is generated, and line_info is
gathered in MCObjectStreamer before writing to
the object file.

After all the information is gathered, the two
sections are emitted in MCObjectStreamer.

Signed-off-by: Song Liu <songliubraving@fb.com>
Signed-off-by: Yonghong Song <yhs@fb.com>